### PR TITLE
Resolve bug not showing plugin repo when no folder is selected

### DIFF
--- a/SwiftBar/App.swift
+++ b/SwiftBar/App.swift
@@ -27,8 +27,22 @@ class App: NSObject {
     }
 
     public static func getPlugins() {
-        if Preferences.shared.pluginDirectoryPath == nil {
-            App.changePluginFolder()
+        while Preferences.shared.pluginDirectoryPath == nil {
+            
+            let alert = NSAlert()
+            alert.messageText = "Set SwiftBar Plugins Location"
+            alert.informativeText = "Select a folder to store the plugins repository"
+            alert.addButton(withTitle: "Ok")
+            alert.addButton(withTitle: "Cancel")
+            let modalResult = alert.runModal()
+
+            switch modalResult {
+            case .alertFirstButtonReturn:
+                App.changePluginFolder()
+            default:
+                return
+            }
+            
         }
         let preferencesWindowController: NSWindowController?
         let myWindow = NSWindow(

--- a/SwiftBar/App.swift
+++ b/SwiftBar/App.swift
@@ -10,7 +10,7 @@ class App: NSObject {
 
     public static func changePluginFolder() {
         let dialog = NSOpenPanel()
-        dialog.title                   = "Choose plugin folder"
+        dialog.message                 = "Choose plugin folder"
         dialog.showsResizeIndicator    = true
         dialog.showsHiddenFiles        = false
         dialog.canChooseDirectories    = true
@@ -27,6 +27,9 @@ class App: NSObject {
     }
 
     public static func getPlugins() {
+        if Preferences.shared.pluginDirectoryPath == nil {
+            App.changePluginFolder()
+        }
         let preferencesWindowController: NSWindowController?
         let myWindow = NSWindow(
             contentRect: .init(origin: .zero, size: CGSize(width: 400, height: 500)),

--- a/SwiftBar/AppDelegate.swift
+++ b/SwiftBar/AppDelegate.swift
@@ -19,8 +19,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             case .alertFirstButtonReturn:
                 App.changePluginFolder()
             default:
-//                NSApplication.shared.terminate(self)
-                return
+                NSApplication.shared.terminate(self)
             }
         }
     }

--- a/SwiftBar/AppDelegate.swift
+++ b/SwiftBar/AppDelegate.swift
@@ -7,7 +7,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ aNotification: Notification) {
         //Instance of Plugin Manager must be created after app launch
         pluginManager = PluginManager.shared
-        if Preferences.shared.pluginDirectoryPath == nil {
+        while Preferences.shared.pluginDirectoryPath == nil {
             let alert = NSAlert()
             alert.messageText = "Set SwiftBar Plugins Location"
             alert.informativeText = "Select a folder to store the plugins repository"

--- a/SwiftBar/AppDelegate.swift
+++ b/SwiftBar/AppDelegate.swift
@@ -10,7 +10,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         while Preferences.shared.pluginDirectoryPath == nil {
             let alert = NSAlert()
             alert.messageText = "Set SwiftBar Plugins Location"
-            alert.informativeText = "Select a folder to store the plugins repository"
+            alert.informativeText = "Select a folder to store the SwiftBar plugins"
             alert.addButton(withTitle: "Ok")
             alert.addButton(withTitle: "Quit SwiftBar")
             let modalResult = alert.runModal()

--- a/SwiftBar/AppDelegate.swift
+++ b/SwiftBar/AppDelegate.swift
@@ -8,7 +8,20 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         //Instance of Plugin Manager must be created after app launch
         pluginManager = PluginManager.shared
         if Preferences.shared.pluginDirectoryPath == nil {
-            App.changePluginFolder()
+            let alert = NSAlert()
+            alert.messageText = "Set SwiftBar Plugins Location"
+            alert.informativeText = "Select a folder to store the plugins repository"
+            alert.addButton(withTitle: "Ok")
+            alert.addButton(withTitle: "Quit SwiftBar")
+            let modalResult = alert.runModal()
+
+            switch modalResult {
+            case .alertFirstButtonReturn:
+                App.changePluginFolder()
+            default:
+//                NSApplication.shared.terminate(self)
+                return
+            }
         }
     }
 


### PR DESCRIPTION
Closes #15 

- Change title to message so that it's visible in Big Sur
- If no plugin directory is selected when calling repo, ask for a folder