### PR TITLE
Fix icon and text together in status item in menu bar

### DIFF
--- a/SwiftBar/MenuBar/MenuBarItem.swift
+++ b/SwiftBar/MenuBar/MenuBarItem.swift
@@ -391,7 +391,7 @@ extension MenubarItem {
         let params = MenuLineParameters(line: title)
         if let image = params.image {
             barItem.button?.image = image
-            return
+            barItem.button?.imagePosition = .imageLeft
         }
         barItem.button?.attributedTitle = atributedTitle(with: params).title
     }


### PR DESCRIPTION
Closes #37 by setting `imagePosition = .imageLeft` on the status item's button, and not returning early when there's an image.

To test confirm all the following work as expected:

- Try outputting just an image.
- Try outputting just text.
- Try outputting an image and text (like the example in the linked issue).

Individual images and text should work without regressions, image and text should be rendered side by side when both are outputted:
<img width="71" alt="Screenshot 2020-11-30 at 10 11 44@2x" src="https://user-images.githubusercontent.com/138576/100597009-cc8af580-32f4-11eb-86ff-fb092e8212ce.png">
