### PR TITLE
make plugin list scroll to top on category change (11.0+)

### DIFF
--- a/SwiftBar/UI/Plugin Repository/PluginRepositoryView.swift
+++ b/SwiftBar/UI/Plugin Repository/PluginRepositoryView.swift
@@ -24,7 +24,6 @@ struct PluginRepositoryView: View {
     }
 }
 
-
 struct PluginEntryView: View {
     enum InstallStatus: String {
         case Install
@@ -141,25 +140,41 @@ struct PluginEntryView: View {
     }
 }
 
-
-struct CategoryDetailView: View {
-    let plugins: [RepositoryEntry.PluginEntry]
+struct CategoryDetailScrollView: View {
+    let category: String
     var body: some View {
+        let plugins = PluginRepository.shared.getPlugins(for: category)
         ScrollView(showsIndicators: true) {
             ForEach(plugins, id: \.self) { plugin in
                 PluginEntryView(pluginEntry: plugin)
                     .padding()
                     .shadow(radius: 20)
+                    .id(plugins.firstIndex(of: plugin))
             }
         }.frame(minWidth: 100, maxWidth: .infinity)
     }
 }
 
+struct CategoryDetailView: View {
+    let category: String
+    var body: some View {
+        if #available(OSX 11.0, *) {
+            ScrollViewReader { proxy in
+                CategoryDetailScrollView(category: category)
+                    .onChange(of: category) { _ in
+                        proxy.scrollTo(0, anchor: .top)
+                    }
+            }
+        } else {
+            CategoryDetailScrollView(category: category)
+        }
+    }
+}
+
 struct Category {
     let category: String
-    let pluginRepository = PluginRepository.shared
     var contentView: CategoryDetailView {
-        return CategoryDetailView(plugins: pluginRepository.getPlugins(for: category))
+        return CategoryDetailView(category: category)
     }
 }
 


### PR DESCRIPTION
First off, lovely project and I really appreciate the recent 1.1.0 release! 

In occasionally browsing plugins, one thing that bothered me as very un-Mac-like is the plugin list not starting at the top upon category change. For example, choose a long list such as `Network`, then scroll way down, then choose e.g. `Finance` and note that the plugin list starts scrolled way down. 

I don't think we should go as far as remembering state between categories, but a simple change of always starting the selected category at the top is IMHO preferable. 

This is my first eyes on SwiftUI, but I think I got this. It only works on 11.0 and up due to need for `ScrollViewReader`/`ScrollViewProxy`, but I think it's pretty clean. 

I'm not able to try it out on 10.15, but I ensured that it worked in 11.0, then worked out the `#available(OS X 11.0, *)` logic so that it would build again on the project 10.15 deployment target. 

Feedback welcome. Again, thanks for a great project. 