### PR TITLE
Make the URL in the About box a hyperlink.

### DIFF
--- a/SwiftBar/Resources/Credits.rtf
+++ b/SwiftBar/Resources/Credits.rtf
@@ -1,8 +1,8 @@
-{\rtf1\ansi\ansicpg1252\cocoartf2513
+{\rtf1\ansi\ansicpg1252\cocoartf2577
 \cocoatextscaling0\cocoaplatform0{\fonttbl\f0\fswiss\fcharset0 Helvetica;}
 {\colortbl;\red255\green255\blue255;}
 {\*\expandedcolortbl;;}
 \margl1440\margr1440\vieww9000\viewh8400\viewkind0
 \pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
 
-\f0\fs24 \cf0 Website: https://swiftbar.app}
+\f0\fs24 \cf0 Website: {\field{\*\fldinst{HYPERLINK "https://swiftbar.app"}}{\fldrslt https://swiftbar.app}}}


### PR DESCRIPTION
Changes

<img width="396" alt="Screen Shot 2021-01-08 at 9 30 15 AM" src="https://user-images.githubusercontent.com/282460/104026563-20aab480-5194-11eb-95c9-e696fe1f3bc3.png">


To

<img width="352" alt="Screen Shot 2021-01-08 at 9 29 38 AM" src="https://user-images.githubusercontent.com/282460/104026519-0a045d80-5194-11eb-89bb-7ecdc15d2648.png">

This fixes #135.