### PR TITLE
Update Copyright date

### DIFF
--- a/SwiftBar/App.swift
+++ b/SwiftBar/App.swift
@@ -103,7 +103,7 @@ class App: NSObject {
     }
 
     public static func showAbout() {
-        NSApp.orderFrontStandardAboutPanel(options: [:])
+        NSApp.orderFrontStandardAboutPanel()
     }
 
     public static func runInTerminal(script: String, runInBackground: Bool = false, env: [String: String] = [:], completionHandler: ((() -> Void)?) = nil) {

--- a/SwiftBar/Resources/Info.plist
+++ b/SwiftBar/Resources/Info.plist
@@ -45,7 +45,7 @@
 	<key>NSAppleEventsUsageDescription</key>
 	<string>Allow SwiftBar to run plugin in Terminal</string>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright ©2020 Ameba Labs. All rights reserved.</string>
+	<string>Copyright ©2020-2021 Ameba Labs. All rights reserved.</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 	<key>SUFeedURL</key>


### PR DESCRIPTION
Fixes #137, as such:

<img width="352" alt="Screen Shot 2021-01-08 at 9 40 56 AM" src="https://user-images.githubusercontent.com/282460/104027599-9c593100-5195-11eb-8297-13acce3ec329.png">

...furthermore, simplified the call to show the about box to omit the optional parameter that wasn't doing anything.