### PR TITLE
Add "href" parameter for notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ For binary plugins metadata can be added as an extended file attribute:
 | refreshplugin | `name` plugin [name](#plugin-naming) | Force refresh plugin by name | `swiftbar://refreshplugin?name=myplugin` |
 | refreshplugin | `index` plugin index in menubar, starting from `0` | Force refresh plugin by its position in menubar | `swiftbar://refreshplugin?index=1` |
 | addplugin | `src` source URL to plugin file | Add plugin to Swiftbar from URL | `swiftbar://addplugin?src=https://coolplugin` |
-| notify | `plugin` plugin [name](#plugin-naming). Notification fields: `title`, `subtitle`, `body`. `open` to open an URL on click. `silent=true` to disable sound | Show notification | `swiftbar://notify?plugin=MyPlugin&title=title&subtitle=subtitle&body=body&silent=true` |
+| notify | `plugin` plugin [name](#plugin-naming). Notification fields: `title`, `subtitle`, `body`. `href` to open an URL on click (including custom URL schemes). `silent=true` to disable sound | Show notification | `swiftbar://notify?plugin=MyPlugin&title=title&subtitle=subtitle&body=body&silent=true` |
 
 ## Preferences aka 'defaults'
 

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ For binary plugins metadata can be added as an extended file attribute:
 | refreshplugin | `name` plugin [name](#plugin-naming) | Force refresh plugin by name | `swiftbar://refreshplugin?name=myplugin` |
 | refreshplugin | `index` plugin index in menubar, starting from `0` | Force refresh plugin by its position in menubar | `swiftbar://refreshplugin?index=1` |
 | addplugin | `src` source URL to plugin file | Add plugin to Swiftbar from URL | `swiftbar://addplugin?src=https://coolplugin` |
-| notify | `plugin` plugin [name](#plugin-naming), notification fields `title`, `subtitle`, `body` and disable sound `silent=true` | Show notification | `swiftbar://notify?plugin=MyPlugin&title=title&subtitle=subtitle&body=body&silent=true` |
+| notify | `plugin` plugin [name](#plugin-naming). Notification fields: `title`, `subtitle`, `body`. `open` to open an URL on click. `silent=true` to disable sound | Show notification | `swiftbar://notify?plugin=MyPlugin&title=title&subtitle=subtitle&body=body&silent=true` |
 
 ## Preferences aka 'defaults'
 

--- a/SwiftBar/AppDelegate.swift
+++ b/SwiftBar/AppDelegate.swift
@@ -125,6 +125,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUStandardUserDriverDelegat
                                                title: url.queryParameters?["title"],
                                                subtitle: url.queryParameters?["subtitle"],
                                                body: url.queryParameters?["body"],
+                                               open: url.queryParameters?["open"],
                                                silent: url.queryParameters?["silent"] == "true")
             default:
                 os_log("Unsupported URL scheme \n %{public}@", log: Log.plugin, type: .error, url.absoluteString)
@@ -132,10 +133,15 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUStandardUserDriverDelegat
         }
     }
 
-    func userNotificationCenter(_: UNUserNotificationCenter, willPresent _: UNNotification,
-                                withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void)
-    {
-        completionHandler([.alert, .sound])
+    func userNotificationCenter(_: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
+        let urlString = response.notification.request.content.userInfo["url"] as? String ?? ""
+
+        if urlString != "" {
+            let url = URL(string: urlString)!
+            NSWorkspace.shared.open(url)
+        }
+
+        completionHandler()
     }
 
     func windowWillClose(_: Notification) {

--- a/SwiftBar/AppDelegate.swift
+++ b/SwiftBar/AppDelegate.swift
@@ -125,7 +125,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUStandardUserDriverDelegat
                                                title: url.queryParameters?["title"],
                                                subtitle: url.queryParameters?["subtitle"],
                                                body: url.queryParameters?["body"],
-                                               open: url.queryParameters?["open"],
+                                               href: url.queryParameters?["href"],
                                                silent: url.queryParameters?["silent"] == "true")
             default:
                 os_log("Unsupported URL scheme \n %{public}@", log: Log.plugin, type: .error, url.absoluteString)
@@ -134,10 +134,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUStandardUserDriverDelegat
     }
 
     func userNotificationCenter(_: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
-        let urlString = response.notification.request.content.userInfo["url"] as? String ?? ""
-
-        if urlString != "" {
-            let url = URL(string: urlString)!
+        if let urlString = response.notification.request.content.userInfo["url"] as? String,
+           let url = URL(string: urlString)
+        {
             NSWorkspace.shared.open(url)
         }
 

--- a/SwiftBar/Plugin/PluginManger.swift
+++ b/SwiftBar/Plugin/PluginManger.swift
@@ -238,7 +238,7 @@ class PluginManager {
 }
 
 extension PluginManager {
-    func showNotification(pluginID: PluginID, title: String?, subtitle: String?, body: String?, silent: Bool = false) {
+    func showNotification(pluginID: PluginID, title: String?, subtitle: String?, body: String?, open: String?, silent: Bool = false) {
         guard let plugin = plugins.first(where: { $0.id == pluginID }),
               plugin.enabled else { return }
 
@@ -248,6 +248,13 @@ extension PluginManager {
         content.body = body ?? ""
         content.sound = silent ? nil : .default
         content.threadIdentifier = pluginID
+
+        let urlString = open ?? ""
+        let url = URL(string: urlString)
+
+        if url?.host != nil, url?.scheme != nil {
+            content.userInfo = ["url": urlString]
+        }
 
         let uuidString = UUID().uuidString
         let request = UNNotificationRequest(identifier: uuidString,

--- a/SwiftBar/Plugin/PluginManger.swift
+++ b/SwiftBar/Plugin/PluginManger.swift
@@ -238,7 +238,7 @@ class PluginManager {
 }
 
 extension PluginManager {
-    func showNotification(pluginID: PluginID, title: String?, subtitle: String?, body: String?, open: String?, silent: Bool = false) {
+    func showNotification(pluginID: PluginID, title: String?, subtitle: String?, body: String?, href: String?, silent: Bool = false) {
         guard let plugin = plugins.first(where: { $0.id == pluginID }),
               plugin.enabled else { return }
 
@@ -249,10 +249,9 @@ extension PluginManager {
         content.sound = silent ? nil : .default
         content.threadIdentifier = pluginID
 
-        let urlString = open ?? ""
-        let url = URL(string: urlString)
-
-        if url?.host != nil, url?.scheme != nil {
+        if let urlString = href,
+           let url = URL(string: urlString), url.host != nil, url.scheme != nil
+        {
             content.userInfo = ["url": urlString]
         }
 


### PR DESCRIPTION
When passing an URL as "href" parameter for "notify", the URL will be open when the user clicks the notification. This can be a web URL or any custom URL scheme.

Same behavior as the "open" parameter of terminal notifier:
https://github.com/julienXX/terminal-notifier#example-uses