### PR TITLE
Stop setting image height to improve display on mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
- <img width="155" height="150" alt="SwiftBar Logo" src="Resources/logo.png">
+ <img width="155" alt="SwiftBar Logo" src="Resources/logo.png">
 </p>
 
 # SwiftBar
@@ -32,7 +32,7 @@ Runs on macOS Catalina (10.15) and up.
 SwiftBar is bundled with a Plugin Repository. You can access it at Swiftbar → Get Plugins...
 
 <p align="center">
- <img width="600" height="500" alt="A screenshot of SwiftBar’s Plugin Repository" src="https://user-images.githubusercontent.com/222100/110520713-d5058000-80dc-11eb-9b15-baa09cb445bf.png">
+ <img width="600" alt="A screenshot of SwiftBar’s Plugin Repository" src="https://user-images.githubusercontent.com/222100/110520713-d5058000-80dc-11eb-9b15-baa09cb445bf.png">
 </p>
 
 If you want to add\remove plugin or have other questions about repository content please refer to this [issue](https://github.com/swiftbar/swiftbar-plugins/issues/1).


### PR DESCRIPTION
If you set the image height as well as width, GitHub will respect the height but not width on mobile, forcing the aspect ratio to be wrong. Fixed it by specifying only width; GitHub will automtically show the image at the right aspect ratio on all devices.

Before:

<img src="https://user-images.githubusercontent.com/464574/124211672-83359b00-dabb-11eb-9308-0537de2d4e5e.png" width=375 />