### PR TITLE
Add support on sfcolor when using sfimage

### DIFF
--- a/SwiftBar/MenuBar/MenuLineParameters.swift
+++ b/SwiftBar/MenuBar/MenuLineParameters.swift
@@ -153,9 +153,20 @@ struct MenuLineParameters: Codable {
     var image: NSImage? {
         if #available(OSX 11.0, *) {
             if let sfString = params["sfimage"] {
-                let config = NSImage.SymbolConfiguration(scale: .large)
+                var config = NSImage.SymbolConfiguration(scale: .large)
+                var template = true
+                if #available(OSX 12.0, *) {
+                    if let color = sfcolor {
+                        config = config.applying(.init(hierarchicalColor: color))
+                        template = false
+
+                        if #available(OSX 13.0, *) {
+                            config = config.applying(NSImage.SymbolConfiguration.preferringMonochrome())
+                        }
+                    }
+                }
                 let image = NSImage(systemSymbolName: sfString, accessibilityDescription: nil)?.withSymbolConfiguration(config)
-                image?.isTemplate = true
+                image?.isTemplate = template
                 return resizedImageIfRequested(image)
             }
         }


### PR DESCRIPTION
Always uses the first defined `sfcolor` (if there is one) to color the `sfimage` defined SF Symbol. On macOS 13 also forces the monochrome representation.

Current caveat: The first `sfcolor` is not consumed and would be used equally for the first appearing SF Symbol in the text representation. I can add proper handling for that as well if desired.