### PR TITLE
fix(streamable): Append read stream buffer to ongoing response for long items

### DIFF
--- a/SwiftBar/Plugin/StreamablePlugin.swift
+++ b/SwiftBar/Plugin/StreamablePlugin.swift
@@ -98,7 +98,7 @@ class StreamablePlugin: Plugin {
                                             self?.content = nil
                                             return
                                         }
-                                        guard str.contains("\n") else {
+                                        guard str.contains("\n") || !str.contains(streamSeparator) else {
                                             self?.streamInProgressContent.append(contentsOf: str)
                                             return
                                         }


### PR DESCRIPTION
Process output is streamed into a buffer. By default this buffer fits 4k characters, which is too short for image data.

With this change, if this block does not contain a stream separator, the complete block is appended to the in-progress content stored so far.

Fixes #371.