### PR TITLE
Add support light/dark image

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Where:
 | ------------- | ------------- |------------- | 
 | `dropdown` | False | Only applicable to items in `Header`. When set to False, item will not be displayed in dropdown menu, but will be cycled in the menu bar. |
 | `alternate` | True | Marks a line as an alternative to the previous one for when the Option key (<kbd style="font-size:medium">⌥</kbd>) is pressed in the dropdown.|
-| `image` | Image encoded in Base64| Sets an image for item.|
+| `image` | Image encoded in Base64, `light_image,dark_image` | Sets an image for item. If only one image is provided, it is used for both light and dark appearance.|
 | `templateImage` | Image encoded in Base64| Same as `image`, but the image is a template image. Template images consist of black and clear colors (and an alpha channel). Template images are not intended to be used as standalone images and are usually mixed with other content to create the desired final appearance.|
 | `sfimage` | SFSymbol name| Sets an image for item from [SF Symbol](https://developer.apple.com/sf-symbols/). Only available on Big Sur and above.|
 | `checked` | True | Sets a checkmark in front of the item.|

--- a/SwiftBar/AppShared.swift
+++ b/SwiftBar/AppShared.swift
@@ -188,6 +188,11 @@ class AppShared: NSObject {
         UserDefaults.standard.string(forKey: "AppleInterfaceStyle") != nil
     }
 
+    public static var isDarkStatusBar: Bool {
+        let currentAppearance = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength).button?.effectiveAppearance
+        return currentAppearance?.bestMatch(from: [.aqua, .darkAqua]) == .aqua
+    }
+
     public static var isReduceTransparencyEnabled: Bool {
         UserDefaults(suiteName: "com.apple.universalaccess.plist")?.bool(forKey: "reduceTransparency") ?? false
     }

--- a/SwiftBar/MenuBar/MenuLineParameters.swift
+++ b/SwiftBar/MenuBar/MenuLineParameters.swift
@@ -254,9 +254,19 @@ struct MenuLineParameters: Codable {
             }
         }
 
-        let image = NSImage.createImage(from: params["image"] ?? params["templateimage"], isTemplate: params["templateimage"] != nil)
+        if (params["image"] != nil) {
+            let images = params["image"]?.components(separatedBy: ",")
+            let lightImage = images?.first
+            let darkImage = images?.last
 
-        return resizedImageIfRequested(image)
+            return resizedImageIfRequested(NSImage.createImage(from: AppShared.isDarkStatusBar || darkImage == nil ? lightImage : darkImage, isTemplate: false))
+        }
+
+        if (params["templateimage"] != nil) {
+            return resizedImageIfRequested(NSImage.createImage(from: params["templateimage"], isTemplate: true))
+        }
+
+        return nil
     }
 
     private func resizedImageIfRequested(_ image: NSImage?) -> NSImage? {


### PR DESCRIPTION
This PR related with https://github.com/swiftbar/SwiftBar/issues/380

I checked a lots of samples for implement like above.
I noticed two things in the end.

- It is impossible that template image with coloring partial point. templateImage with tint is very similar but only one color tone applied.
- Most of apps that implemented "template image with coloring partial point" uses two non-template image for light/dark status bar appearance.

This PR implements two images for light/dark status bar appearance.
