### PR TITLE
fix: pluginList filter

### DIFF
--- a/SwiftBar/Plugin/PluginManger.swift
+++ b/SwiftBar/Plugin/PluginManger.swift
@@ -191,7 +191,13 @@ class PluginManager: ObservableObject {
         }
 
         if !dirs.isEmpty {
-            files.append(contentsOf: dirs.map { filter(url: $0) }.flatMap(\.files))
+            for dir in dirs {
+                let (subFiles, _) = filter(url: dir)
+                let (filteredSubFiles, _) = ingoreFileContent.map {
+                    filterFilesAndDirs(files: subFiles, dirs: [], ignoreContent: $0)
+                } ?? (subFiles, [])
+                files.append(contentsOf: filteredSubFiles)
+            }
         }
         return Array(Set(files))
     }


### PR DESCRIPTION
#### TL;DR: Prevent ignored files from being re-included via subdirectory traversal

Hi, and thank you so much for this awesome project! ❤️
I really appreciate the work you’ve put into making it clean and useful.

While integrating the plugin system, I noticed a small issue in the file filtering logic:
Even if a file is correctly ignored via `.swiftbarignore` rules (e.g., `test2/test2.sh`), it could still be re-included later when traversing its parent directory (`test2/`) recursively. This behavior breaks the expectation that once a file is ignored, it should never be returned.

🔧 What this PR fixes

This PR ensures that ignored files remain excluded, even when walking through directories that themselves are not ignored. It does so by reapplying the ignore patterns during recursive traversal of filteredDirs.

✅ Example

Given a directory (can be download at [test_filter.zip](https://github.com/user-attachments/files/20667442/test_filter.zip)):
```
test1.sh
test2/
  └── test2.sh
```
With `.swiftbarignore` content:
```
test2/test2.sh
```
Previously: `test2/test2.sh` was still returned.
After this PR: only `test1.sh` is returned, as expected.

---

Let me know if you’d like any changes or test cases added — happy to iterate! Thanks again for your fantastic work! 🚀