### PR TITLE
feat: add badge support to menu items

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Where:
 | `sfconfig` | SFSymbol configuration| Configures [Rendering Mode](https://developer.apple.com/design/human-interface-guidelines/sf-symbols#Rendering-modes) for `sfimage`. Accepts a json encoded as base64, example json `{"renderingMode":"Palette", "colors":["red","blue"], "scale": "large", "weight": "bold"}`. Original issue #354 |
 | `checked` | True | Sets a checkmark in front of the item.|
 | `tooltip` | Text | Sets a tooltip for the item. |
+| `badge` | Text | Sets text to be displayed in a badge to the right of the item |
 | `webview` | True | Present provided href as a webview, instead of standard menu bar menu |
 | `webvieww` | Number | Sets webview width in pixels |
 | `webviewh` | Number | Sets webview height in pixels |

--- a/SwiftBar/MenuBar/MenuBarItem.swift
+++ b/SwiftBar/MenuBar/MenuBarItem.swift
@@ -754,6 +754,12 @@ extension MenubarItem {
             item.state = .on
         }
 
+        if #available(macOS 14.0, *) {
+            if !params.badge.isEmpty {
+                item.badge = NSMenuItemBadge(string: params.badge)
+            }
+        }
+
         return item
     }
 

--- a/SwiftBar/MenuBar/MenuLineParameters.swift
+++ b/SwiftBar/MenuBar/MenuLineParameters.swift
@@ -224,6 +224,10 @@ struct MenuLineParameters: Codable {
         return out
     }
 
+    var badge: String {
+        params["badge"] ?? ""
+    }
+
     var terminal: Bool {
         params["terminal"]?.lowercased() != "false"
     }


### PR DESCRIPTION
This one is pretty simple, adding badge support for menu items. I wanted to be able to display a count to the number of services I have running for my dev stack. Here's a screenshot, where you can see the badge on the "Trigger" menu item:

<img width="242" height="198" alt="image" src="https://github.com/user-attachments/assets/940a65f7-5ef6-4a6d-bec4-ec0228adaf66" />