### PR TITLE
feat: add tab stop to enable right-aligned content

### DIFF
--- a/SwiftBar/MenuBar/MenuBarItem.swift
+++ b/SwiftBar/MenuBar/MenuBarItem.swift
@@ -20,6 +20,7 @@ class MenubarItem: NSObject {
     }()
 
     let statusBarMenu = NSMenu(title: "")
+    let defaultTabStop: CGFloat = 150
     let titleCylleInterval: Double = 5
     var contentUpdateCancellable: AnyCancellable?
     var titleCycleCancellable: AnyCancellable?
@@ -705,6 +706,7 @@ extension MenubarItem {
 
         let style = NSMutableParagraphStyle()
         style.alignment = pad ? .center : .left
+        style.tabStops = [NSTextTab(textAlignment: .right, location: defaultTabStop, options: [:])]
 
         var attributedTitle = NSMutableAttributedString(string: title)
         if #available(macOS 12, *), params.md, let parsedMD = try? NSAttributedString(markdown: title) {


### PR DESCRIPTION
Another (hopefully) quick win. This adds a single right-aligned tabstop to the menu item title text, which allows for images and text to be anchored on the right by separating them with the `\t` character.

Example screenshot:

<img width="221" height="166" alt="image" src="https://github.com/user-attachments/assets/052ef682-8373-4a94-823d-23bd0c154cd6" />

I've picked a default tab stop of 150 points, as I think this is reasonable enough as a first pass. However, I could add more tab stops for potentially wider menus. My original thought was to allow configurable tabstops through params, but I'm not sure what the format should look like as you'd need both a number for the location and an alignment string. I'm happy to follow up on this with improvements if there's a concrete approach. Either way, I think some level of default is useful.

Caveat: it doesn't look quite so good when there are submenus or badges, but it's great for submenus that don't have those things.

<img width="246" height="304" alt="image" src="https://github.com/user-attachments/assets/a83a4c43-e104-40b5-bff9-8679941ba750" />
