### PR TITLE
Fix #455

### DIFF
--- a/SwiftBar/MenuBar/MenuBarItem.swift
+++ b/SwiftBar/MenuBar/MenuBarItem.swift
@@ -658,6 +658,7 @@ extension MenubarItem {
     // do the following conversion:
     // \\ -> \
     // \n -> LF
+    // \t -> TAB
     // \c -> c  any char else
     func unescape(_ str: String) -> String {
         var newstr = ""
@@ -667,6 +668,10 @@ extension MenubarItem {
                 backslash = false
                 if c == "n" {
                     newstr += "\n"
+                    continue
+                }
+                if c == "t" {
+                    newstr += "\t"
                     continue
                 }
             } else {
@@ -705,6 +710,15 @@ extension MenubarItem {
 
         let style = NSMutableParagraphStyle()
         style.alignment = pad ? .center : .left
+
+        // Configure tab stops for proper tab alignment (issue #455)
+        // Add tab stops every 100 points to support tab-aligned text
+        var tabStops: [NSTextTab] = []
+        for i in 1...10 {
+            let location = CGFloat(i * 100)
+            tabStops.append(NSTextTab(textAlignment: .left, location: location))
+        }
+        style.tabStops = tabStops
 
         var attributedTitle = NSMutableAttributedString(string: title)
         if #available(macOS 12, *), params.md, let parsedMD = try? NSAttributedString(markdown: title) {

--- a/SwiftBarTests/SwiftBarTests.swift
+++ b/SwiftBarTests/SwiftBarTests.swift
@@ -239,6 +239,29 @@ struct PluginMetadataEnvironmentParsingTests {
         #expect(!exportString.contains("VAR_MONOSPACE_FONT: font"))
     }
 
+    @Test func testMenuLineParameters_TabCharacterHandling() throws {
+        // Test the fix for issue #455: tab character handling
+        // The unescape function should convert \t escape sequences to actual tab characters
+
+        // Test that the title is extracted correctly (with escape sequences preserved as literal characters)
+        let line1 = "Hello\\tWorld | bash='/bin/echo'"
+        let params1 = MenuLineParameters(line: line1)
+        // The title contains the literal backslash and t characters
+        #expect(params1.title.contains("\\"), "Title should contain backslash")
+        #expect(params1.title.contains("t"), "Title should contain t")
+
+        // Test multiple escapes
+        let line2 = "Column1\\tColumn2\\tColumn3"
+        let params2 = MenuLineParameters(line: line2)
+        #expect(params2.title.contains("\\"), "Title should contain backslashes")
+
+        // Test mixed escapes
+        let line3 = "Test\\tTab\\nNewline | color=blue"
+        let params3 = MenuLineParameters(line: line3)
+        #expect(params3.title.contains("\\"), "Title should contain escape characters")
+        #expect(params3.params["color"] == "blue", "Parameters should be parsed correctly")
+    }
+
     @Test func testIssue445_ShellExportString() throws {
         // Test that environment variables with equals signs in values are properly escaped
         // This addresses the specific tcsh export error mentioned in the issue


### PR DESCRIPTION
<img width="1100" height="1028" alt="Screenshot 2025-11-07 at 14 11 31" src="https://github.com/user-attachments/assets/6c846b9f-9deb-4951-bd53-d11eed42f54a" />

```
#!/bin/bash

# <xbar.title>Tab Character Test</xbar.title>
# <xbar.version>v1.0</xbar.version>
# <xbar.author>Test</xbar.author>
# <xbar.desc>Test plugin to verify tab character handling for issue #455</xbar.desc>

# Menu bar title
echo "Tabs Test"

# Separator
echo "---"

# Test basic tab
echo "Hello\tWorld"

# Test multiple tabs with alignment
echo "Column1\tColumn2\tColumn3"
echo "A\tB\tC"
echo "Long Text\tShort\tMedium Text"

# Test tabs with parameters
echo "Tab Test\twith color | color=blue"
echo "Tab Test\twith font | font=Monaco size=14"

# Test mixing tabs and newlines (newlines for multi-line menu items)
echo "Line1\tTabbed"
echo "Line2\tAlso Tabbed"

# Test in submenu
echo "Submenu Test"
echo "--Item 1\tValue 1"
echo "--Item 2\tValue 2"
echo "--Item 3\tValue 3"

# Test with emoji
echo "📊 Data\t✅ Status"

# Test escaping still works
echo "Path\\with\\backslashes"
echo "Mix\tTab and\\nNewline"
```