### PR TITLE
Fix memory leaks in status bar item creation and menu rebuilds

### DIFF
--- a/SwiftBar/AppShared.swift
+++ b/SwiftBar/AppShared.swift
@@ -203,7 +203,9 @@ class AppShared: NSObject {
     }
 
     public static var isDarkStatusBar: Bool {
-        let currentAppearance = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength).button?.effectiveAppearance
+        let item = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
+        let currentAppearance = item.button?.effectiveAppearance
+        NSStatusBar.system.removeStatusItem(item)
         return currentAppearance?.bestMatch(from: [.aqua, .darkAqua]) == .aqua
     }
 

--- a/SwiftBar/MenuBar/MenuBarItem.swift
+++ b/SwiftBar/MenuBar/MenuBarItem.swift
@@ -500,6 +500,9 @@ extension MenubarItem {
     func _updateMenu(content: String?) {
         barItem.button?.appearsDisabled = false
         statusBarMenu.removeAllItems()
+        hotKeys.removeAll()
+        prevItems.removeAll()
+        prevLevel = 0
         resetWebPopoverContent()
         show()
 


### PR DESCRIPTION
## Summary

- **Fix NSStatusItem leak in `isDarkStatusBar`**: The computed property was creating a new `NSStatusItem` on every call via `NSStatusBar.system.statusItem(withLength:)` without ever calling `removeStatusItem()`. Since this is called from `MenuLineParameters.getImage()` for every menu item with `image=`, `templateImage=`, `sfimage=`, or `color=` parameters, it leaked one phantom status bar item per menu item per refresh cycle. Over time this caused unbounded memory growth.
- **Clear `hotKeys` array on menu rebuild**: `_updateMenu` was calling `statusBarMenu.removeAllItems()` but never clearing the `hotKeys` array, causing duplicate `HotKey` handlers to accumulate across refreshes.
- **Reset `prevItems`/`prevLevel` on menu rebuild**: Old `NSMenuItem` references were retained in `prevItems` between refreshes, preventing deallocation until the next parse.

## Test plan

Tested with a stress-test plugin generating 200 menu items with base64 `image=` parameters every 3 seconds:

| Build | Start RSS | RSS after 2 min | Trend |
|---|---|---|---|
| **Stock SwiftBar** | 114 MB | 316 MB | +200 MB, monotonic growth |
| **Patched build** | 134 MB | 95 MB | Stable/declining |

The stock build leaked ~100 MB/min under this load. The patched build stayed flat with memory being properly reclaimed by ARC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)