### PR TITLE
Add fold=true parameter for accordion-style menu sections

### DIFF
--- a/SwiftBar.xcodeproj/project.pbxproj
+++ b/SwiftBar.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		CC467003000000000000A103 /* MenuItemNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC467001000000000000A101 /* MenuItemNode.swift */; };
 		CC467005000000000000A105 /* MenuDiff.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC467004000000000000A104 /* MenuDiff.swift */; };
 		CC467006000000000000A106 /* MenuDiff.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC467004000000000000A104 /* MenuDiff.swift */; };
+		CC467008000000000000A108 /* FoldableMenuItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC467007000000000000A107 /* FoldableMenuItemView.swift */; };
 		3920747E25460FD000213DBE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3920747D25460FD000213DBE /* AppDelegate.swift */; };
 		3920748225460FD300213DBE /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3920748125460FD300213DBE /* Assets.xcassets */; };
 		3920748525460FD300213DBE /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3920748425460FD300213DBE /* Preview Assets.xcassets */; };
@@ -209,6 +210,7 @@
 		39AF777B254618F6001D76E5 /* MenuBarItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarItem.swift; sourceTree = "<group>"; };
 		CC467001000000000000A101 /* MenuItemNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuItemNode.swift; sourceTree = "<group>"; };
 		CC467004000000000000A104 /* MenuDiff.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuDiff.swift; sourceTree = "<group>"; };
+		CC467007000000000000A107 /* FoldableMenuItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoldableMenuItemView.swift; sourceTree = "<group>"; };
 		39AF77832547750E001D76E5 /* AppShared.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppShared.swift; sourceTree = "<group>"; };
 		39AF778C2548EBA3001D76E5 /* MenuLineParameters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuLineParameters.swift; sourceTree = "<group>"; };
 		39AF7792254B5834001D76E5 /* NSColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSColor.swift; sourceTree = "<group>"; };
@@ -414,6 +416,7 @@
 		398B86D4254DC01800DEA027 /* MenuBar */ = {
 			isa = PBXGroup;
 			children = (
+				CC467007000000000000A107 /* FoldableMenuItemView.swift */,
 				39AF777B254618F6001D76E5 /* MenuBarItem.swift */,
 				CC467004000000000000A104 /* MenuDiff.swift */,
 				CC467001000000000000A101 /* MenuItemNode.swift */,
@@ -840,6 +843,7 @@
 				39AF778D2548EBA3001D76E5 /* MenuLineParameters.swift in Sources */,
 				CC467002000000000000A102 /* MenuItemNode.swift in Sources */,
 				CC467005000000000000A105 /* MenuDiff.swift in Sources */,
+				CC467008000000000000A108 /* FoldableMenuItemView.swift in Sources */,
 				FAD1BC9E25D22EEA00B761E8 /* AnimatableWindow.swift in Sources */,
 				39AF7796254B6203001D76E5 /* NSImage.swift in Sources */,
 				398B86CE254DBF2F00DEA027 /* main.swift in Sources */,

--- a/SwiftBar/MenuBar/FoldableMenuItemView.swift
+++ b/SwiftBar/MenuBar/FoldableMenuItemView.swift
@@ -13,7 +13,7 @@ class FoldableMenuItemView: NSView {
         static let leadingPadding: CGFloat = 18
         static let iconTrailingSpacing: CGFloat = 4
         static let chevronLeadingSpacing: CGFloat = 8
-        static let trailingPadding: CGFloat = 12
+        static let trailingPadding: CGFloat = 16
         static let highlightInsetX: CGFloat = 4
         static let highlightInsetY: CGFloat = 1
         static let highlightCornerRadius: CGFloat = 4

--- a/SwiftBar/MenuBar/FoldableMenuItemView.swift
+++ b/SwiftBar/MenuBar/FoldableMenuItemView.swift
@@ -1,0 +1,162 @@
+import Cocoa
+
+/// A custom NSView for foldable menu items that prevents menu dismissal on click.
+/// When an NSMenuItem has a `view` set, clicking it does NOT close the menu,
+/// which enables accordion/fold behavior in the dropdown.
+class FoldableMenuItemView: NSView {
+    private let titleField = NSTextField(labelWithString: "")
+    private let chevronView = NSImageView()
+    private let iconView = NSImageView()
+    var isFolded: Bool {
+        didSet {
+            updateChevron()
+        }
+    }
+    var onToggle: (() -> Void)?
+
+    private var trackingArea: NSTrackingArea?
+    private var isHighlighted = false
+
+    init(attributedTitle: NSAttributedString, image: NSImage?, isFolded: Bool) {
+        self.isFolded = isFolded
+        super.init(frame: NSRect(x: 0, y: 0, width: 0, height: 22))
+        autoresizingMask = [.width]
+
+        setupViews(attributedTitle: attributedTitle, image: image)
+        updateChevron()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Setup
+
+    private func setupViews(attributedTitle: NSAttributedString, image: NSImage?) {
+        titleField.attributedStringValue = attributedTitle
+        titleField.isEditable = false
+        titleField.isBordered = false
+        titleField.drawsBackground = false
+        titleField.lineBreakMode = .byTruncatingTail
+        titleField.maximumNumberOfLines = 1
+        titleField.cell?.wraps = false
+        titleField.cell?.isScrollable = false
+        titleField.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        titleField.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(titleField)
+
+        chevronView.imageScaling = .scaleProportionallyDown
+        chevronView.translatesAutoresizingMaskIntoConstraints = false
+        chevronView.setContentHuggingPriority(.required, for: .horizontal)
+        addSubview(chevronView)
+
+        iconView.translatesAutoresizingMaskIntoConstraints = false
+        iconView.imageScaling = .scaleProportionallyDown
+        addSubview(iconView)
+
+        let hasImage = image != nil
+        iconView.image = image
+        iconView.isHidden = !hasImage
+
+        let iconWidth: CGFloat = hasImage ? 18 : 0
+        let iconTrailingPad: CGFloat = hasImage ? 4 : 0
+
+        NSLayoutConstraint.activate([
+            iconView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 18),
+            iconView.centerYAnchor.constraint(equalTo: centerYAnchor),
+            iconView.widthAnchor.constraint(equalToConstant: iconWidth),
+            iconView.heightAnchor.constraint(equalToConstant: 16),
+
+            titleField.leadingAnchor.constraint(equalTo: iconView.trailingAnchor, constant: iconTrailingPad),
+            titleField.centerYAnchor.constraint(equalTo: centerYAnchor),
+            titleField.trailingAnchor.constraint(lessThanOrEqualTo: chevronView.leadingAnchor, constant: -8),
+
+            chevronView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -12),
+            chevronView.centerYAnchor.constraint(equalTo: centerYAnchor),
+            chevronView.widthAnchor.constraint(equalToConstant: 10),
+            chevronView.heightAnchor.constraint(equalToConstant: 12),
+        ])
+    }
+
+    private func updateChevron() {
+        // Use the same chevron SF Symbol as standard submenu indicators
+        let symbolName = isFolded ? "chevron.right" : "chevron.down"
+        if let symbol = NSImage(systemSymbolName: symbolName, accessibilityDescription: nil) {
+            let config = NSImage.SymbolConfiguration(pointSize: 10, weight: .semibold)
+            chevronView.image = symbol.withSymbolConfiguration(config)
+            chevronView.contentTintColor = isHighlighted ? .white : .tertiaryLabelColor
+        }
+    }
+
+    // MARK: - Layout
+
+    override var intrinsicContentSize: NSSize {
+        NSSize(width: NSView.noIntrinsicMetric, height: 22)
+    }
+
+    // MARK: - Tracking & Highlighting
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        if let trackingArea {
+            removeTrackingArea(trackingArea)
+        }
+        trackingArea = NSTrackingArea(
+            rect: bounds,
+            options: [.mouseEnteredAndExited, .activeAlways],
+            owner: self,
+            userInfo: nil
+        )
+        addTrackingArea(trackingArea!)
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        isHighlighted = true
+        updateChevron()
+        needsDisplay = true
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        isHighlighted = false
+        updateChevron()
+        needsDisplay = true
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        if isHighlighted {
+            NSColor.selectedContentBackgroundColor.setFill()
+            let path = NSBezierPath(roundedRect: bounds.insetBy(dx: 4, dy: 1), xRadius: 4, yRadius: 4)
+            path.fill()
+            titleField.textColor = .white
+        } else {
+            titleField.textColor = .labelColor
+        }
+    }
+
+    // MARK: - Click Handling
+
+    override func mouseUp(with event: NSEvent) {
+        isFolded.toggle()
+        onToggle?()
+
+        // Brief highlight flash
+        isHighlighted = true
+        updateChevron()
+        needsDisplay = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+            self?.isHighlighted = false
+            self?.updateChevron()
+            self?.needsDisplay = true
+        }
+    }
+
+    // MARK: - Update
+
+    /// Update the view's title and image without replacing the view.
+    func update(attributedTitle: NSAttributedString, image: NSImage?) {
+        titleField.attributedStringValue = attributedTitle
+        iconView.image = image
+        iconView.isHidden = image == nil
+    }
+}

--- a/SwiftBar/MenuBar/FoldableMenuItemView.swift
+++ b/SwiftBar/MenuBar/FoldableMenuItemView.swift
@@ -62,11 +62,20 @@ class FoldableMenuItemView: NSView {
         let iconWidth: CGFloat = hasImage ? 18 : 0
         let iconTrailingPad: CGFloat = hasImage ? 4 : 0
 
+        let iconWidthConstraint = iconView.widthAnchor.constraint(equalToConstant: iconWidth)
+        iconWidthConstraint.priority = .defaultHigh
+        let iconHeightConstraint = iconView.heightAnchor.constraint(equalToConstant: 16)
+        iconHeightConstraint.priority = .defaultHigh
+        let chevronWidthConstraint = chevronView.widthAnchor.constraint(equalToConstant: 10)
+        chevronWidthConstraint.priority = .defaultHigh
+        let chevronHeightConstraint = chevronView.heightAnchor.constraint(equalToConstant: 12)
+        chevronHeightConstraint.priority = .defaultHigh
+
         NSLayoutConstraint.activate([
             iconView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 18),
             iconView.centerYAnchor.constraint(equalTo: centerYAnchor),
-            iconView.widthAnchor.constraint(equalToConstant: iconWidth),
-            iconView.heightAnchor.constraint(equalToConstant: 16),
+            iconWidthConstraint,
+            iconHeightConstraint,
 
             titleField.leadingAnchor.constraint(equalTo: iconView.trailingAnchor, constant: iconTrailingPad),
             titleField.centerYAnchor.constraint(equalTo: centerYAnchor),
@@ -74,8 +83,8 @@ class FoldableMenuItemView: NSView {
 
             chevronView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -12),
             chevronView.centerYAnchor.constraint(equalTo: centerYAnchor),
-            chevronView.widthAnchor.constraint(equalToConstant: 10),
-            chevronView.heightAnchor.constraint(equalToConstant: 12),
+            chevronWidthConstraint,
+            chevronHeightConstraint,
         ])
     }
 

--- a/SwiftBar/MenuBar/FoldableMenuItemView.swift
+++ b/SwiftBar/MenuBar/FoldableMenuItemView.swift
@@ -4,6 +4,26 @@ import Cocoa
 /// When an NSMenuItem has a `view` set, clicking it does NOT close the menu,
 /// which enables accordion/fold behavior in the dropdown.
 class FoldableMenuItemView: NSView {
+    // MARK: - Layout Constants
+
+    private enum Layout {
+        static let itemHeight: CGFloat = 22
+        static let iconSize = NSSize(width: 18, height: 16)
+        static let chevronSize = NSSize(width: 10, height: 12)
+        static let leadingPadding: CGFloat = 18
+        static let iconTrailingSpacing: CGFloat = 4
+        static let chevronLeadingSpacing: CGFloat = 8
+        static let trailingPadding: CGFloat = 12
+        static let highlightInsetX: CGFloat = 4
+        static let highlightInsetY: CGFloat = 1
+        static let highlightCornerRadius: CGFloat = 4
+        static let chevronPointSize: CGFloat = 10
+    }
+
+    private static let chevronSymbolConfig = NSImage.SymbolConfiguration(pointSize: Layout.chevronPointSize, weight: .semibold)
+
+    // MARK: - Views
+
     private let titleField = NSTextField(labelWithString: "")
     private let chevronView = NSImageView()
     private let iconView = NSImageView()
@@ -19,8 +39,12 @@ class FoldableMenuItemView: NSView {
 
     init(attributedTitle: NSAttributedString, image: NSImage?, isFolded: Bool) {
         self.isFolded = isFolded
-        super.init(frame: NSRect(x: 0, y: 0, width: 0, height: 22))
+        super.init(frame: NSRect(x: 0, y: 0, width: 0, height: Layout.itemHeight))
         autoresizingMask = [.width]
+        setAccessibilityRole(.button)
+        setAccessibilitySubrole(.toggle)
+        setAccessibilityLabel(attributedTitle.string)
+        setAccessibilityValue(isFolded ? "collapsed" : "expanded")
 
         setupViews(attributedTitle: attributedTitle, image: image)
         updateChevron()
@@ -59,29 +83,29 @@ class FoldableMenuItemView: NSView {
         iconView.image = image
         iconView.isHidden = !hasImage
 
-        let iconWidth: CGFloat = hasImage ? 18 : 0
-        let iconTrailingPad: CGFloat = hasImage ? 4 : 0
+        let iconWidth: CGFloat = hasImage ? Layout.iconSize.width : 0
+        let iconTrailingPad: CGFloat = hasImage ? Layout.iconTrailingSpacing : 0
 
         let iconWidthConstraint = iconView.widthAnchor.constraint(equalToConstant: iconWidth)
         iconWidthConstraint.priority = .defaultHigh
-        let iconHeightConstraint = iconView.heightAnchor.constraint(equalToConstant: 16)
+        let iconHeightConstraint = iconView.heightAnchor.constraint(equalToConstant: Layout.iconSize.height)
         iconHeightConstraint.priority = .defaultHigh
-        let chevronWidthConstraint = chevronView.widthAnchor.constraint(equalToConstant: 10)
+        let chevronWidthConstraint = chevronView.widthAnchor.constraint(equalToConstant: Layout.chevronSize.width)
         chevronWidthConstraint.priority = .defaultHigh
-        let chevronHeightConstraint = chevronView.heightAnchor.constraint(equalToConstant: 12)
+        let chevronHeightConstraint = chevronView.heightAnchor.constraint(equalToConstant: Layout.chevronSize.height)
         chevronHeightConstraint.priority = .defaultHigh
 
         NSLayoutConstraint.activate([
-            iconView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 18),
+            iconView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Layout.leadingPadding),
             iconView.centerYAnchor.constraint(equalTo: centerYAnchor),
             iconWidthConstraint,
             iconHeightConstraint,
 
             titleField.leadingAnchor.constraint(equalTo: iconView.trailingAnchor, constant: iconTrailingPad),
             titleField.centerYAnchor.constraint(equalTo: centerYAnchor),
-            titleField.trailingAnchor.constraint(lessThanOrEqualTo: chevronView.leadingAnchor, constant: -8),
+            titleField.trailingAnchor.constraint(lessThanOrEqualTo: chevronView.leadingAnchor, constant: -Layout.chevronLeadingSpacing),
 
-            chevronView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -12),
+            chevronView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Layout.trailingPadding),
             chevronView.centerYAnchor.constraint(equalTo: centerYAnchor),
             chevronWidthConstraint,
             chevronHeightConstraint,
@@ -89,35 +113,35 @@ class FoldableMenuItemView: NSView {
     }
 
     private func updateChevron() {
-        // Use the same chevron SF Symbol as standard submenu indicators
         let symbolName = isFolded ? "chevron.right" : "chevron.down"
-        if let symbol = NSImage(systemSymbolName: symbolName, accessibilityDescription: nil) {
-            let config = NSImage.SymbolConfiguration(pointSize: 10, weight: .semibold)
-            chevronView.image = symbol.withSymbolConfiguration(config)
+        if let symbol = NSImage(systemSymbolName: symbolName, accessibilityDescription: isFolded ? "collapsed" : "expanded") {
+            chevronView.image = symbol.withSymbolConfiguration(Self.chevronSymbolConfig)
             chevronView.contentTintColor = isHighlighted ? .white : .tertiaryLabelColor
         }
+        setAccessibilityValue(isFolded ? "collapsed" : "expanded")
     }
 
     // MARK: - Layout
 
     override var intrinsicContentSize: NSSize {
-        NSSize(width: NSView.noIntrinsicMetric, height: 22)
+        NSSize(width: NSView.noIntrinsicMetric, height: Layout.itemHeight)
     }
 
     // MARK: - Tracking & Highlighting
 
     override func updateTrackingAreas() {
         super.updateTrackingAreas()
-        if let trackingArea {
-            removeTrackingArea(trackingArea)
+        if let existing = trackingArea {
+            removeTrackingArea(existing)
         }
-        trackingArea = NSTrackingArea(
+        let area = NSTrackingArea(
             rect: bounds,
             options: [.mouseEnteredAndExited, .activeAlways],
             owner: self,
             userInfo: nil
         )
-        addTrackingArea(trackingArea!)
+        addTrackingArea(area)
+        trackingArea = area
     }
 
     override func mouseEntered(with event: NSEvent) {
@@ -135,7 +159,8 @@ class FoldableMenuItemView: NSView {
     override func draw(_ dirtyRect: NSRect) {
         if isHighlighted {
             NSColor.selectedContentBackgroundColor.setFill()
-            let path = NSBezierPath(roundedRect: bounds.insetBy(dx: 4, dy: 1), xRadius: 4, yRadius: 4)
+            let inset = bounds.insetBy(dx: Layout.highlightInsetX, dy: Layout.highlightInsetY)
+            let path = NSBezierPath(roundedRect: inset, xRadius: Layout.highlightCornerRadius, yRadius: Layout.highlightCornerRadius)
             path.fill()
             titleField.textColor = .white
         } else {
@@ -160,11 +185,24 @@ class FoldableMenuItemView: NSView {
         }
     }
 
+    override func keyDown(with event: NSEvent) {
+        // Space or Enter toggles the fold
+        if event.keyCode == 36 || event.keyCode == 49 {
+            isFolded.toggle()
+            onToggle?()
+        } else {
+            super.keyDown(with: event)
+        }
+    }
+
+    override var acceptsFirstResponder: Bool { true }
+
     // MARK: - Update
 
     /// Update the view's title and image without replacing the view.
     func update(attributedTitle: NSAttributedString, image: NSImage?) {
         titleField.attributedStringValue = attributedTitle
+        setAccessibilityLabel(attributedTitle.string)
         iconView.image = image
         iconView.isHidden = image == nil
     }

--- a/SwiftBar/MenuBar/MenuBarItem.swift
+++ b/SwiftBar/MenuBar/MenuBarItem.swift
@@ -55,6 +55,8 @@ class MenubarItem: NSObject {
 
     /// Tracks which fold parent NSMenuItems are currently expanded.
     private var expandedFoldItems: Set<ObjectIdentifier> = []
+    /// Fold expansion state tracked by working line, survives full rebuilds.
+    private var expandedFoldLines: Set<String> = []
     /// NSMenuItems injected as fold children, keyed by parent NSMenuItem identity.
     private var foldChildItems: [ObjectIdentifier: [NSMenuItem]] = [:]
 
@@ -567,6 +569,8 @@ extension MenubarItem {
         prevLevel = 0
         expandedFoldItems.removeAll()
         foldChildItems.removeAll()
+        // Note: expandedFoldLines is intentionally NOT cleared here
+        // so that fold state survives full rebuilds.
         resetWebPopoverContent()
         show()
         defer {
@@ -653,7 +657,7 @@ extension MenubarItem {
 
         // Calculate the base index in statusBarMenu where body items start.
         // Layout: [title items...] [separator] [body items...] [standard items...]
-        let oldBodyCount = countMenuItems(in: currentMenuTree)
+        let oldBodyCount = countMenuItems(in: currentMenuTree, for: statusBarMenu)
         let bodyBaseIndex = pluginItemCount - oldBodyCount
 
         // Validate index assumptions; fall back to full rebuild if out of sync.
@@ -669,7 +673,7 @@ extension MenubarItem {
         applyDiff(changes, oldTree: currentMenuTree, newTree: newTree, to: statusBarMenu, baseIndex: bodyBaseIndex)
 
         // Update tracking state
-        pluginItemCount = pluginItemCount - oldBodyCount + countMenuItems(in: newTree)
+        pluginItemCount = pluginItemCount - oldBodyCount + countMenuItems(in: newTree, for: statusBarMenu)
         currentMenuTree = newTree
         restoreTitleCycleIfNeeded()
         syncHotKeys()
@@ -682,9 +686,16 @@ extension MenubarItem {
 
     /// Count the NSMenuItems in the flat menu that belong to the plugin content.
     /// Includes root-level nodes plus any fold children injected as siblings.
-    private func countMenuItems(in nodes: [MenuItemNode]) -> Int {
-        let foldChildCount = foldChildItems.values.reduce(0) { $0 + $1.count }
-        return nodes.count + foldChildCount
+    /// Counts only fold children that are actually inserted into the target menu.
+    private func countMenuItems(in nodes: [MenuItemNode], for menu: NSMenu) -> Int {
+        var uniqueChildren = Set<ObjectIdentifier>()
+        for items in foldChildItems.values {
+            for item in items {
+                guard item.menu === menu else { continue }
+                uniqueChildren.insert(ObjectIdentifier(item))
+            }
+        }
+        return nodes.count + uniqueChildren.count
     }
 
     /// Apply a diff to a live NSMenu, patching items in-place.
@@ -727,11 +738,17 @@ extension MenubarItem {
                             let childKey = ObjectIdentifier(child)
                             foldChildItems.removeValue(forKey: childKey)
                             expandedFoldItems.remove(childKey)
+                            if let childParams = child.representedObject as? MenuLineParameters {
+                                expandedFoldLines.remove(childParams.title)
+                            }
                             menu.removeItem(at: childIndex)
                         }
                     }
                 }
                 expandedFoldItems.remove(key)
+                if let params = item.representedObject as? MenuLineParameters {
+                    expandedFoldLines.remove(params.title)
+                }
                 menu.removeItem(at: menu.index(of: item))
             }
         }
@@ -776,6 +793,7 @@ extension MenubarItem {
                 buildSubmenuItems(for: newItem, from: newNode, into: menu)
             }
         } else {
+            let oldParams = MenuLineParameters(line: oldNode.workingLine)
             let newParams = MenuLineParameters(line: newNode.workingLine)
             if !oldNode.contentEqual(to: newNode) {
                 if let foldView = existingItem.view as? FoldableMenuItemView, newParams.fold {
@@ -785,9 +803,12 @@ extension MenubarItem {
                     patchMenuItem(existingItem, with: newParams)
                 }
             }
-            if oldNode.children != newNode.children {
-                let oldParams = MenuLineParameters(line: oldNode.workingLine)
+            let foldModeChanged = oldParams.fold != newParams.fold
+            if oldNode.children != newNode.children || foldModeChanged {
                 if newParams.fold {
+                    if foldModeChanged {
+                        existingItem.submenu = nil
+                    }
                     updateFoldChildren(of: existingItem, from: newNode, in: menu)
                 } else if oldParams.fold {
                     // Transitioning from fold to submenu: clean up fold children first
@@ -834,24 +855,19 @@ extension MenubarItem {
         }
 
         // Patch direct children in-place where possible
-        let oldDirectCount = existingChildren.count
         let newDirectChildren = newNode.children
 
         // Count only direct children (not nested fold grandchildren) in existing list
         var directItems: [NSMenuItem] = []
-        var i = 0
-        for child in existingChildren {
+        var index = 0
+        while index < existingChildren.count {
+            let child = existingChildren[index]
             let childKey = ObjectIdentifier(child)
+            directItems.append(child)
             if let nestedChildren = foldChildItems[childKey] {
-                // This is a nested fold parent — skip its children in the flat list
-                directItems.append(child)
-                i += 1 + nestedChildren.count
+                index += 1 + nestedChildren.count
             } else {
-                directItems.append(child)
-                i += 1
-            }
-            if directItems.count >= newDirectChildren.count && i >= existingChildren.count {
-                break
+                index += 1
             }
         }
 
@@ -1048,10 +1064,14 @@ extension MenubarItem {
     /// and attach a FoldableMenuItemView to the parent item.
     private func buildFoldChildren(for item: NSMenuItem, from node: MenuItemNode, into menu: NSMenu) {
         let key = ObjectIdentifier(item)
-        let isExpanded = expandedFoldItems.contains(key)
+        let params = MenuLineParameters(line: node.workingLine)
+        // Check ObjectIdentifier first (incremental), fall back to line-based state (rebuild)
+        let isExpanded = expandedFoldItems.contains(key) || expandedFoldLines.contains(params.title)
+        if isExpanded {
+            expandedFoldItems.insert(key)
+        }
 
         // Attach the foldable view to the parent item
-        let params = MenuLineParameters(line: node.workingLine)
         let titleInfo = atributedTitle(with: params)
         let foldView = FoldableMenuItemView(
             attributedTitle: titleInfo.title,
@@ -1115,6 +1135,15 @@ extension MenubarItem {
             expandedFoldItems.insert(key)
         }
 
+        // Also track by line for cross-rebuild persistence
+        if let params = item.representedObject as? MenuLineParameters {
+            if wasExpanded {
+                expandedFoldLines.remove(params.title)
+            } else {
+                expandedFoldLines.insert(params.title)
+            }
+        }
+
         if let children = foldChildItems[key] {
             for child in children {
                 child.isHidden = wasExpanded
@@ -1136,6 +1165,9 @@ extension MenubarItem {
             let key = ObjectIdentifier(item)
             guard foldChildItems[key] != nil else { continue }
             expandedFoldItems.remove(key)
+            if let params = item.representedObject as? MenuLineParameters {
+                expandedFoldLines.remove(params.title)
+            }
             if let view = item.view as? FoldableMenuItemView {
                 view.isFolded = true
             }

--- a/SwiftBar/MenuBar/MenuBarItem.swift
+++ b/SwiftBar/MenuBar/MenuBarItem.swift
@@ -46,6 +46,18 @@ class MenubarItem: NSObject {
     var hotkeyTrigger: Bool = false
     var showsAllStandardItemsWhileOpen = false
 
+    /// Tracks the current tree of parsed menu nodes for incremental diffing.
+    var currentMenuTree: [MenuItemNode] = []
+    /// Header lines from the last rendered content, used to detect header changes.
+    var currentHeaderLines: [String] = []
+    /// Number of NSMenuItems that belong to plugin content (header + separator + body).
+    var pluginItemCount: Int = 0
+
+    /// Tracks which fold parent NSMenuItems are currently expanded.
+    private var expandedFoldItems: Set<ObjectIdentifier> = []
+    /// NSMenuItems injected as fold children, keyed by parent NSMenuItem identity.
+    private var foldChildItems: [ObjectIdentifier: [NSMenuItem]] = [:]
+
     private var aboutPopover = NSPopover()
     private var errorPopover = NSPopover()
     private var webPopover = NSPopover()
@@ -155,10 +167,6 @@ class MenubarItem: NSObject {
         contentUpdateCancellable = plugin?.contentUpdatePublisher
             .receive(on: menuUpdateQueue)
             .sink { [weak self] content in
-                guard self?.isOpen == false else {
-                    self?.refreshOnClose = true
-                    return
-                }
                 self?.disableTitleCycle()
                 self?.updateMenu(content: content)
             }
@@ -557,6 +565,8 @@ extension MenubarItem {
         hotKeys.removeAll()
         prevItems.removeAll()
         prevLevel = 0
+        expandedFoldItems.removeAll()
+        foldChildItems.removeAll()
         resetWebPopoverContent()
         show()
         defer {
@@ -589,29 +599,56 @@ extension MenubarItem {
             statusBarMenu.addItem(NSMenuItem.separator())
         }
 
-        // prevItems.append(statusBarMenu.items.last)
-        for line in parts.body {
-            addMenuItem(from: line)
+        // Build the tree first so fold items know their children at construction time
+        let tree = MenuItemNode.buildMenuTree(from: parts.body)
+        for node in tree {
+            if node.isSeparator {
+                statusBarMenu.addItem(NSMenuItem.separator())
+            } else if let item = buildMenuItem(params: MenuLineParameters(line: node.workingLine)) {
+                item.target = self
+                statusBarMenu.addItem(item)
+                buildSubmenuItems(for: item, from: node, into: statusBarMenu)
+            }
         }
 
         // Track how many items belong to the plugin content.
-        // Includes title/header items + optional separator + body root-level items.
+        // Includes title/header items + optional separator + body root-level items + fold children.
         // Standard menu items (SwiftBar submenu, etc.) are appended after this point.
+        currentHeaderLines = parts.header
+        currentMenuTree = tree
         pluginItemCount = statusBarMenu.items.count
-        currentMenuTree = MenuItemNode.buildMenuTree(from: parts.body)
         syncHotKeys()
         buildStandardMenu()
     }
 
+    /// Body-only incremental update for use while the menu is open.
+    /// Patches body items in-place without touching the header or title.
+    /// Called from the content subscriber when the menu is open.
     /// Incremental update: diffs old vs new tree and patches the live menu.
     /// This runs while the menu may be open, enabling live content updates
     /// without waiting for the menu to close and rebuild.
     private func incrementalUpdateMenu(content: String, header: [String], body: [String], newTree: [MenuItemNode]) {
         dispatchPrecondition(condition: .onQueue(.main))
 
-        if header != currentHeaderLines || body.isEmpty {
+        if body.isEmpty || header.count != currentHeaderLines.count {
             fullRebuildMenu(content: content)
             return
+        }
+
+        // Update header/title in-place if content changed (avoids full rebuild)
+        if header != currentHeaderLines {
+            titleLines = header
+            currentHeaderLines = header
+            setMenuTitle(title: header.first ?? "")
+            // Patch header items in the menu for multi-line titles
+            if header.count > 1 {
+                for (index, line) in header.enumerated() {
+                    guard index < statusBarMenu.items.count else { break }
+                    let item = statusBarMenu.items[index]
+                    guard !item.isSeparatorItem else { break }
+                    patchMenuItem(item, with: MenuLineParameters(line: line))
+                }
+            }
         }
 
         // Calculate the base index in statusBarMenu where body items start.
@@ -643,26 +680,59 @@ extension MenubarItem {
         }
     }
 
-    /// Count the visible root-level NSMenuItems represented by the diff tree.
+    /// Count the NSMenuItems in the flat menu that belong to the plugin content.
+    /// Includes root-level nodes plus any fold children injected as siblings.
     private func countMenuItems(in nodes: [MenuItemNode]) -> Int {
-        nodes.count
+        let foldChildCount = foldChildItems.values.reduce(0) { $0 + $1.count }
+        return nodes.count + foldChildCount
     }
 
     /// Apply a diff to a live NSMenu, patching items in-place.
     private func applyDiff(_ changes: [MenuItemChange], oldTree: [MenuItemNode], newTree: [MenuItemNode], to menu: NSMenu, baseIndex: Int) {
-        applyRemovals(changes, to: menu, baseIndex: baseIndex)
+        applyRemovals(changes, oldTree: oldTree, to: menu, baseIndex: baseIndex)
         applyUpdatesAndInserts(changes, oldTree: oldTree, newTree: newTree, to: menu, baseIndex: baseIndex)
+    }
+
+    /// Compute the actual menu index for a node index, accounting for fold children
+    /// inserted as siblings before this position.
+    private func actualMenuIndex(for nodeIndex: Int, in menu: NSMenu, baseIndex: Int, nodes: [MenuItemNode]) -> Int {
+        var offset = 0
+        for i in 0 ..< nodeIndex {
+            let itemIndex = baseIndex + i + offset
+            guard itemIndex < menu.items.count else { break }
+            let item = menu.items[itemIndex]
+            let key = ObjectIdentifier(item)
+            if let children = foldChildItems[key] {
+                offset += children.count
+            }
+        }
+        return baseIndex + nodeIndex + offset
     }
 
     /// Remove items from the menu. Removals arrive in reverse index order from
     /// diffMenuNodes so that earlier indices are not invalidated.
-    private func applyRemovals(_ changes: [MenuItemChange], to menu: NSMenu, baseIndex: Int) {
+    private func applyRemovals(_ changes: [MenuItemChange], oldTree: [MenuItemNode], to menu: NSMenu, baseIndex: Int) {
         for change in changes {
             if case .remove(let oldIndex) = change {
-                let menuIndex = baseIndex + oldIndex
-                if menuIndex < menu.items.count {
-                    menu.removeItem(at: menuIndex)
+                let menuIndex = actualMenuIndex(for: oldIndex, in: menu, baseIndex: baseIndex, nodes: oldTree)
+                guard menuIndex < menu.items.count else { continue }
+                let item = menu.items[menuIndex]
+
+                // Remove fold children first (in reverse to preserve indices)
+                let key = ObjectIdentifier(item)
+                if let children = foldChildItems.removeValue(forKey: key) {
+                    for child in children.reversed() {
+                        if let childIndex = menu.items.firstIndex(of: child) {
+                            // Clean up nested fold state
+                            let childKey = ObjectIdentifier(child)
+                            foldChildItems.removeValue(forKey: childKey)
+                            expandedFoldItems.remove(childKey)
+                            menu.removeItem(at: childIndex)
+                        }
+                    }
                 }
+                expandedFoldItems.remove(key)
+                menu.removeItem(at: menu.index(of: item))
             }
         }
     }
@@ -675,10 +745,12 @@ extension MenubarItem {
                 break
 
             case .update(let oldIndex, let newIndex):
-                applyUpdate(menu: menu, baseIndex: baseIndex, oldNode: oldTree[oldIndex], newNode: newTree[newIndex], newIndex: newIndex)
+                let menuIndex = actualMenuIndex(for: newIndex, in: menu, baseIndex: baseIndex, nodes: newTree)
+                applyUpdate(menu: menu, menuIndex: menuIndex, oldNode: oldTree[oldIndex], newNode: newTree[newIndex])
 
             case .insert(let newIndex):
-                applyInsert(menu: menu, baseIndex: baseIndex, newNode: newTree[newIndex], newIndex: newIndex)
+                let menuIndex = actualMenuIndex(for: newIndex, in: menu, baseIndex: baseIndex, nodes: newTree)
+                applyInsert(menu: menu, menuIndex: menuIndex, newNode: newTree[newIndex])
 
             case .remove:
                 break // Already handled in applyRemovals
@@ -687,8 +759,7 @@ extension MenubarItem {
     }
 
     /// Update a single existing menu item to match a new node.
-    private func applyUpdate(menu: NSMenu, baseIndex: Int, oldNode: MenuItemNode, newNode: MenuItemNode, newIndex: Int) {
-        let menuIndex = baseIndex + newIndex
+    private func applyUpdate(menu: NSMenu, menuIndex: Int, oldNode: MenuItemNode, newNode: MenuItemNode) {
         guard menuIndex < menu.items.count else { return }
         let existingItem = menu.items[menuIndex]
 
@@ -702,27 +773,136 @@ extension MenubarItem {
             if let newItem = buildMenuItem(params: MenuLineParameters(line: newNode.workingLine)) {
                 newItem.target = self
                 menu.insertItem(newItem, at: menuIndex)
-                buildSubmenuItems(for: newItem, from: newNode)
+                buildSubmenuItems(for: newItem, from: newNode, into: menu)
             }
         } else {
+            let newParams = MenuLineParameters(line: newNode.workingLine)
             if !oldNode.contentEqual(to: newNode) {
-                patchMenuItem(existingItem, with: MenuLineParameters(line: newNode.workingLine))
+                if let foldView = existingItem.view as? FoldableMenuItemView, newParams.fold {
+                    let titleInfo = atributedTitle(with: newParams)
+                    foldView.update(attributedTitle: titleInfo.title, image: newParams.image)
+                } else {
+                    patchMenuItem(existingItem, with: newParams)
+                }
             }
             if oldNode.children != newNode.children {
-                updateSubmenu(of: existingItem, oldChildren: oldNode.children, newChildren: newNode.children)
+                let oldParams = MenuLineParameters(line: oldNode.workingLine)
+                if newParams.fold {
+                    updateFoldChildren(of: existingItem, from: newNode, in: menu)
+                } else if oldParams.fold {
+                    // Transitioning from fold to submenu: clean up fold children first
+                    removeFoldChildren(of: existingItem, from: menu)
+                    existingItem.view = nil
+                    updateSubmenu(of: existingItem, oldChildren: [], newChildren: newNode.children)
+                } else {
+                    updateSubmenu(of: existingItem, oldChildren: oldNode.children, newChildren: newNode.children)
+                }
             }
         }
     }
 
     /// Insert a new menu item for a node that did not exist in the old tree.
-    private func applyInsert(menu: NSMenu, baseIndex: Int, newNode: MenuItemNode, newIndex: Int) {
-        let menuIndex = baseIndex + newIndex
+    private func applyInsert(menu: NSMenu, menuIndex: Int, newNode: MenuItemNode) {
+        let clampedIndex = min(menuIndex, menu.items.count)
         if newNode.isSeparator {
-            menu.insertItem(NSMenuItem.separator(), at: min(menuIndex, menu.items.count))
+            menu.insertItem(NSMenuItem.separator(), at: clampedIndex)
         } else if let newItem = buildMenuItem(params: MenuLineParameters(line: newNode.workingLine)) {
             newItem.target = self
-            menu.insertItem(newItem, at: min(menuIndex, menu.items.count))
-            buildSubmenuItems(for: newItem, from: newNode)
+            menu.insertItem(newItem, at: clampedIndex)
+            buildSubmenuItems(for: newItem, from: newNode, into: menu)
+        }
+    }
+
+    /// Update fold children for an existing fold item when its children change.
+    /// Patches existing fold child NSMenuItems in-place to preserve object identity
+    /// (and thus fold expansion state).
+    private func updateFoldChildren(of item: NSMenuItem, from newNode: MenuItemNode, in menu: NSMenu) {
+        let key = ObjectIdentifier(item)
+        let isExpanded = expandedFoldItems.contains(key)
+
+        // Update the fold parent's view
+        let params = MenuLineParameters(line: newNode.workingLine)
+        if let foldView = item.view as? FoldableMenuItemView {
+            let titleInfo = atributedTitle(with: params)
+            foldView.update(attributedTitle: titleInfo.title, image: params.image)
+        }
+
+        guard let existingChildren = foldChildItems[key] else {
+            // No existing fold children — build from scratch
+            buildFoldChildren(for: item, from: newNode, into: menu)
+            return
+        }
+
+        // Patch direct children in-place where possible
+        let oldDirectCount = existingChildren.count
+        let newDirectChildren = newNode.children
+
+        // Count only direct children (not nested fold grandchildren) in existing list
+        var directItems: [NSMenuItem] = []
+        var i = 0
+        for child in existingChildren {
+            let childKey = ObjectIdentifier(child)
+            if let nestedChildren = foldChildItems[childKey] {
+                // This is a nested fold parent — skip its children in the flat list
+                directItems.append(child)
+                i += 1 + nestedChildren.count
+            } else {
+                directItems.append(child)
+                i += 1
+            }
+            if directItems.count >= newDirectChildren.count && i >= existingChildren.count {
+                break
+            }
+        }
+
+        // Simple approach: if direct child count matches, patch in-place.
+        // Otherwise, tear down and rebuild (preserving parent expansion state).
+        if directItems.count == newDirectChildren.count {
+            for (idx, newChild) in newDirectChildren.enumerated() {
+                guard idx < directItems.count else { break }
+                let existingChild = directItems[idx]
+
+                if newChild.isSeparator {
+                    // Separators don't need patching
+                    continue
+                }
+
+                let childParams = MenuLineParameters(line: newChild.workingLine)
+                if let foldView = existingChild.view as? FoldableMenuItemView, childParams.fold {
+                    let titleInfo = atributedTitle(with: childParams)
+                    foldView.update(attributedTitle: titleInfo.title, image: childParams.image)
+                } else if existingChild.view == nil {
+                    patchMenuItem(existingChild, with: childParams)
+                }
+
+                // Recursively update nested fold children
+                let childKey = ObjectIdentifier(existingChild)
+                if childParams.fold, foldChildItems[childKey] != nil {
+                    updateFoldChildren(of: existingChild, from: newChild, in: menu)
+                }
+            }
+        } else {
+            // Child count changed — rebuild (but preserve parent expansion state)
+            removeFoldChildren(of: item, from: menu)
+            buildFoldChildren(for: item, from: newNode, into: menu)
+        }
+    }
+
+    /// Remove all fold children of an item from the menu.
+    private func removeFoldChildren(of item: NSMenuItem, from menu: NSMenu) {
+        let key = ObjectIdentifier(item)
+        if let children = foldChildItems.removeValue(forKey: key) {
+            for child in children.reversed() {
+                // Recursively remove nested fold children
+                let childKey = ObjectIdentifier(child)
+                if foldChildItems[childKey] != nil {
+                    removeFoldChildren(of: child, from: menu)
+                }
+                expandedFoldItems.remove(childKey)
+                if let idx = menu.items.firstIndex(of: child) {
+                    menu.removeItem(at: idx)
+                }
+            }
         }
     }
 
@@ -841,17 +1021,127 @@ extension MenubarItem {
     }
 
     /// Build submenu items from scratch for a newly inserted node.
-    private func buildSubmenuItems(for item: NSMenuItem, from node: MenuItemNode) {
+    /// When the node's params have `fold=true`, children are inserted as hidden
+    /// siblings in the parent menu instead of being placed in an NSSubmenu.
+    private func buildSubmenuItems(for item: NSMenuItem, from node: MenuItemNode, into menu: NSMenu? = nil) {
         guard !node.children.isEmpty else { return }
-        item.submenu = NSMenu(title: "")
-        guard let submenu = item.submenu else { return }
+
+        let params = MenuLineParameters(line: node.workingLine)
+        if params.fold, let targetMenu = menu ?? item.menu {
+            buildFoldChildren(for: item, from: node, into: targetMenu)
+        } else {
+            item.submenu = NSMenu(title: "")
+            guard let submenu = item.submenu else { return }
+            for child in node.children {
+                if child.isSeparator {
+                    submenu.addItem(NSMenuItem.separator())
+                } else if let childItem = buildMenuItem(params: MenuLineParameters(line: child.workingLine)) {
+                    childItem.target = self
+                    submenu.addItem(childItem)
+                    buildSubmenuItems(for: childItem, from: child, into: submenu)
+                }
+            }
+        }
+    }
+
+    /// Build fold children: insert child items as hidden siblings in the parent menu,
+    /// and attach a FoldableMenuItemView to the parent item.
+    private func buildFoldChildren(for item: NSMenuItem, from node: MenuItemNode, into menu: NSMenu) {
+        let key = ObjectIdentifier(item)
+        let isExpanded = expandedFoldItems.contains(key)
+
+        // Attach the foldable view to the parent item
+        let params = MenuLineParameters(line: node.workingLine)
+        let titleInfo = atributedTitle(with: params)
+        let foldView = FoldableMenuItemView(
+            attributedTitle: titleInfo.title,
+            image: params.image,
+            isFolded: !isExpanded
+        )
+        foldView.onToggle = { [weak self] in
+            self?.toggleFoldItem(item)
+        }
+        item.view = foldView
+
+        // Build child items and insert them as siblings after the parent.
+        // Track insertPos rather than using offset, because recursive nested fold
+        // calls insert additional items that shift positions.
+        var children: [NSMenuItem] = []
+        var insertPos = (menu.index(of: item) != -1) ? menu.index(of: item) + 1 : menu.items.count
+
         for child in node.children {
+            let childItem: NSMenuItem
             if child.isSeparator {
-                submenu.addItem(NSMenuItem.separator())
-            } else if let childItem = buildMenuItem(params: MenuLineParameters(line: child.workingLine)) {
-                childItem.target = self
-                submenu.addItem(childItem)
-                buildSubmenuItems(for: childItem, from: child)
+                childItem = NSMenuItem.separator()
+            } else if let built = buildMenuItem(params: MenuLineParameters(line: child.workingLine)) {
+                built.target = self
+                childItem = built
+            } else {
+                continue
+            }
+
+            childItem.isHidden = !isExpanded
+            menu.insertItem(childItem, at: insertPos)
+            children.append(childItem)
+            insertPos += 1
+
+            // Recursively handle nested folds or submenus
+            if !child.children.isEmpty {
+                buildSubmenuItems(for: childItem, from: child, into: menu)
+                // Collect any fold children that were just added for this nested item
+                let nestedKey = ObjectIdentifier(childItem)
+                if let nestedChildren = foldChildItems[nestedKey] {
+                    // Nested fold children are also hidden when outer fold is collapsed
+                    if !isExpanded {
+                        nestedChildren.forEach { $0.isHidden = true }
+                    }
+                    children.append(contentsOf: nestedChildren)
+                    insertPos += nestedChildren.count
+                }
+            }
+        }
+
+        foldChildItems[key] = children
+    }
+
+    /// Toggle the fold state of a menu item.
+    func toggleFoldItem(_ item: NSMenuItem) {
+        let key = ObjectIdentifier(item)
+        let wasExpanded = expandedFoldItems.contains(key)
+
+        if wasExpanded {
+            expandedFoldItems.remove(key)
+        } else {
+            expandedFoldItems.insert(key)
+        }
+
+        if let children = foldChildItems[key] {
+            for child in children {
+                child.isHidden = wasExpanded
+            }
+            // When collapsing, also collapse any nested folds
+            if wasExpanded {
+                collapseNestedFolds(in: children)
+            }
+        }
+
+        if let menu = item.menu {
+            menu.update()
+        }
+    }
+
+    /// Recursively collapse nested fold items within a set of children.
+    private func collapseNestedFolds(in items: [NSMenuItem]) {
+        for item in items {
+            let key = ObjectIdentifier(item)
+            guard foldChildItems[key] != nil else { continue }
+            expandedFoldItems.remove(key)
+            if let view = item.view as? FoldableMenuItemView {
+                view.isFolded = true
+            }
+            if let nestedChildren = foldChildItems[key] {
+                nestedChildren.forEach { $0.isHidden = true }
+                collapseNestedFolds(in: nestedChildren)
             }
         }
     }

--- a/SwiftBar/MenuBar/MenuLineParameters.swift
+++ b/SwiftBar/MenuBar/MenuLineParameters.swift
@@ -305,6 +305,10 @@ struct MenuLineParameters: Codable, Equatable {
         params["alternate"]?.lowercased() == "true"
     }
 
+    var fold: Bool {
+        params["fold"]?.lowercased() == "true"
+    }
+
     func getSFConfig() -> SFConfig? {
         guard let base64 = params["sfconfig"]?.data(using: .utf8),
               let decodedData = Data(base64Encoded: base64),

--- a/SwiftBarTests/SwiftBarTests.swift
+++ b/SwiftBarTests/SwiftBarTests.swift
@@ -1,3 +1,4 @@
+import Cocoa
 import Combine
 import Foundation
 import Testing
@@ -1928,11 +1929,23 @@ struct FoldMenuItemBuildTests {
     private func menuLabels(for item: MenubarItem) -> [String] {
         item.statusBarMenu.items.map { menuItem in
             if menuItem.isSeparatorItem { return "<separator>" }
-            if let view = menuItem.view as? FoldableMenuItemView {
+            if menuItem.view is FoldableMenuItemView {
                 return "<fold>"
             }
             return menuItem.attributedTitle?.string ?? menuItem.title
         }
+    }
+
+    @MainActor
+    private func menuItem(named title: String, in menu: NSMenu) -> NSMenuItem? {
+        menu.items.first { menuItem in
+            (menuItem.representedObject as? MenuLineParameters)?.title == title
+        }
+    }
+
+    @MainActor
+    private func menuItemTitle(_ item: NSMenuItem) -> String {
+        item.attributedTitle?.string ?? item.title
     }
 
     @MainActor @Test func testFullBuild_foldItemStartsCollapsed() throws {
@@ -2068,6 +2081,86 @@ struct FoldMenuItemBuildTests {
         #expect(item.statusBarMenu.items[updatedFoldIndex + 1].isHidden == false)
     }
 
+    @MainActor @Test func testIncrementalUpdate_preservesNestedSubmenuFoldWithoutFullRebuild() throws {
+        let item = makeMenuBarItem()
+
+        item._updateMenu(content: """
+        Title
+        ---
+        Section
+        --Nested Fold | fold=true
+        ----Deep A
+        ----Deep B
+        Status: OK
+        """)
+        item.menuWillOpen(item.statusBarMenu)
+
+        let sectionItem = try #require(menuItem(named: "Section", in: item.statusBarMenu))
+        let nestedFold = try #require(sectionItem.submenu?.items.first { $0.view is FoldableMenuItemView })
+        item.toggleFoldItem(nestedFold)
+        #expect(sectionItem.submenu?.items[1].isHidden == false)
+
+        item._updateMenu(content: """
+        Title
+        ---
+        Section
+        --Nested Fold | fold=true
+        ----Deep A
+        ----Deep B
+        Status: Updated
+        """)
+
+        let updatedSectionItem = try #require(menuItem(named: "Section", in: item.statusBarMenu))
+        let updatedNestedFold = try #require(updatedSectionItem.submenu?.items.first { $0.view is FoldableMenuItemView })
+        #expect(updatedSectionItem === sectionItem)
+        #expect(updatedNestedFold === nestedFold)
+        #expect(updatedSectionItem.submenu?.items[1].isHidden == false)
+    }
+
+    @MainActor @Test func testIncrementalUpdate_rebuildsItemWhenFoldFlagChanges() throws {
+        let item = makeMenuBarItem()
+
+        item._updateMenu(content: """
+        Title
+        ---
+        Section | fold=true
+        --Child A
+        --Child B
+        """)
+
+        let foldSection = try #require(menuItem(named: "Section", in: item.statusBarMenu))
+        #expect(foldSection.view is FoldableMenuItemView)
+        #expect(menuItem(named: "Child A", in: item.statusBarMenu) != nil)
+
+        item._updateMenu(content: """
+        Title
+        ---
+        Section
+        --Child A
+        --Child B
+        """)
+
+        let submenuSection = try #require(menuItem(named: "Section", in: item.statusBarMenu))
+        #expect(submenuSection === foldSection)
+        #expect(submenuSection.view == nil)
+        #expect(submenuSection.submenu?.items.count == 2)
+        #expect(menuItem(named: "Child A", in: item.statusBarMenu) == nil)
+
+        item._updateMenu(content: """
+        Title
+        ---
+        Section | fold=true
+        --Child A
+        --Child B
+        """)
+
+        let rebuiltFoldSection = try #require(menuItem(named: "Section", in: item.statusBarMenu))
+        #expect(rebuiltFoldSection === foldSection)
+        #expect(rebuiltFoldSection.view is FoldableMenuItemView)
+        #expect(rebuiltFoldSection.submenu == nil)
+        #expect(menuItem(named: "Child A", in: item.statusBarMenu) != nil)
+    }
+
     @MainActor @Test func testNestedFold_outerToggleHidesInnerChildren() throws {
         let item = makeMenuBarItem()
 
@@ -2104,5 +2197,38 @@ struct FoldMenuItemBuildTests {
         // Deep children should also be hidden
         #expect(item.statusBarMenu.items[innerIndex + 1].isHidden == true)
     }
-}
 
+    @MainActor @Test func testIncrementalUpdate_nestedFoldKeepsDirectChildrenAligned() throws {
+        let item = makeMenuBarItem()
+
+        item._updateMenu(content: """
+        Title
+        ---
+        Outer | fold=true
+        --Inner | fold=true
+        ----Deep A
+        ----Deep B
+        --Regular Child
+        """)
+
+        let outerFold = item.statusBarMenu.items.first { $0.view is FoldableMenuItemView }!
+        item.toggleFoldItem(outerFold)
+
+        item._updateMenu(content: """
+        Title
+        ---
+        Outer | fold=true
+        --Inner | fold=true
+        ----Deep A
+        ----Deep B
+        --Regular Child Updated
+        """)
+
+        let outerIndex = item.statusBarMenu.index(of: outerFold)
+        let deepAItem = item.statusBarMenu.items[outerIndex + 2]
+        let regularChildItem = item.statusBarMenu.items[outerIndex + 4]
+
+        #expect(menuItemTitle(deepAItem) == "Deep A")
+        #expect(menuItemTitle(regularChildItem) == "Regular Child Updated")
+    }
+}

--- a/SwiftBarTests/SwiftBarTests.swift
+++ b/SwiftBarTests/SwiftBarTests.swift
@@ -1885,3 +1885,224 @@ struct MenuDiffTests {
         #expect(changes[3] == .insert(newIndex: 3))
     }
 }
+
+// MARK: - Fold Parameter Tests
+
+struct FoldParameterTests {
+    @Test func testFoldParam_parsedAsTrue() throws {
+        let params = MenuLineParameters(line: "Network | fold=true")
+        #expect(params.fold == true)
+    }
+
+    @Test func testFoldParam_defaultsToFalse() throws {
+        let params = MenuLineParameters(line: "Network | color=red")
+        #expect(params.fold == false)
+    }
+
+    @Test func testFoldParam_caseInsensitive() throws {
+        let params = MenuLineParameters(line: "Network | fold=True")
+        #expect(params.fold == true)
+        let params2 = MenuLineParameters(line: "Network | fold=TRUE")
+        #expect(params2.fold == true)
+    }
+
+    @Test func testFoldParam_explicitFalse() throws {
+        let params = MenuLineParameters(line: "Network | fold=false")
+        #expect(params.fold == false)
+    }
+}
+
+// MARK: - Fold Menu Item Tests
+
+struct FoldMenuItemBuildTests {
+    @MainActor
+    private func makeMenuBarItem() -> MenubarItem {
+        let plugin = TestPlugin(id: "test-plugin", file: "/tmp/test-plugin.5s.sh", content: nil, lastState: .Success)
+        let item = MenubarItem(title: "Test")
+        item.plugin = plugin
+        item.statusBarMenu.delegate = item
+        return item
+    }
+
+    @MainActor
+    private func menuLabels(for item: MenubarItem) -> [String] {
+        item.statusBarMenu.items.map { menuItem in
+            if menuItem.isSeparatorItem { return "<separator>" }
+            if let view = menuItem.view as? FoldableMenuItemView {
+                return "<fold>"
+            }
+            return menuItem.attributedTitle?.string ?? menuItem.title
+        }
+    }
+
+    @MainActor @Test func testFullBuild_foldItemStartsCollapsed() throws {
+        let item = makeMenuBarItem()
+
+        item._updateMenu(content: """
+        Title
+        ---
+        Network | fold=true
+        --Wi-Fi: Connected
+        --Ethernet: Off
+        Item B
+        """)
+
+        // fold parent + 2 hidden children + Item B + standard menu items
+        let labels = menuLabels(for: item)
+        #expect(labels.contains("<fold>"))
+        #expect(labels.contains("Item B"))
+
+        // The fold children should be hidden
+        let foldIndex = labels.firstIndex(of: "<fold>")!
+        let childItem1 = item.statusBarMenu.items[foldIndex + 1]
+        let childItem2 = item.statusBarMenu.items[foldIndex + 2]
+        #expect(childItem1.isHidden == true)
+        #expect(childItem2.isHidden == true)
+        #expect(childItem1.attributedTitle?.string == "Wi-Fi: Connected")
+        #expect(childItem2.attributedTitle?.string == "Ethernet: Off")
+    }
+
+    @MainActor @Test func testFullBuild_foldItemExpandsOnToggle() throws {
+        let item = makeMenuBarItem()
+
+        item._updateMenu(content: """
+        Title
+        ---
+        Network | fold=true
+        --Wi-Fi: Connected
+        --Ethernet: Off
+        """)
+
+        // Find the fold parent
+        let foldParent = item.statusBarMenu.items.first { $0.view is FoldableMenuItemView }!
+
+        // Toggle to expand
+        item.toggleFoldItem(foldParent)
+
+        // Children should now be visible
+        let foldIndex = item.statusBarMenu.index(of: foldParent)
+        let childItem1 = item.statusBarMenu.items[foldIndex + 1]
+        let childItem2 = item.statusBarMenu.items[foldIndex + 2]
+        #expect(childItem1.isHidden == false)
+        #expect(childItem2.isHidden == false)
+
+        // Toggle to collapse
+        item.toggleFoldItem(foldParent)
+
+        #expect(childItem1.isHidden == true)
+        #expect(childItem2.isHidden == true)
+    }
+
+    @MainActor @Test func testFullBuild_nonFoldItemUsesSubmenu() throws {
+        let item = makeMenuBarItem()
+
+        item._updateMenu(content: """
+        Title
+        ---
+        Section
+        --Sub A
+        --Sub B
+        """)
+
+        // Regular submenu behavior (no fold)
+        let sectionItem = item.statusBarMenu.items.first {
+            $0.attributedTitle?.string == "Section"
+        }!
+        #expect(sectionItem.view == nil)
+        #expect(sectionItem.submenu != nil)
+        #expect(sectionItem.submenu?.items.count == 2)
+    }
+
+    @MainActor @Test func testFullBuild_pluginItemCountIncludesFoldChildren() throws {
+        let item = makeMenuBarItem()
+
+        item._updateMenu(content: """
+        Title
+        ---
+        Fold Parent | fold=true
+        --Child A
+        --Child B
+        Regular Item
+        """)
+
+        // pluginItemCount should include: separator + fold parent + 2 fold children + regular item
+        // = 1 (title sep) + 1 (fold parent) + 2 (fold children) + 1 (regular) = 5
+        // Plus however many title items are before the separator
+        let expectedBodyItems = 5 // sep + fold parent + 2 children + regular
+        #expect(item.pluginItemCount >= expectedBodyItems)
+    }
+
+    @MainActor @Test func testIncrementalUpdate_preservesFoldStateOnContentUpdate() throws {
+        let item = makeMenuBarItem()
+
+        item._updateMenu(content: """
+        Title
+        ---
+        Network | fold=true
+        --Wi-Fi: Connected
+        --Ethernet: Off
+        Status: OK
+        """)
+
+        // Expand the fold
+        let foldParent = item.statusBarMenu.items.first { $0.view is FoldableMenuItemView }!
+        item.toggleFoldItem(foldParent)
+
+        // Verify expanded
+        let foldIndex = item.statusBarMenu.index(of: foldParent)
+        #expect(item.statusBarMenu.items[foldIndex + 1].isHidden == false)
+
+        // Update content (non-fold item changes)
+        item._updateMenu(content: """
+        Title
+        ---
+        Network | fold=true
+        --Wi-Fi: Connected
+        --Ethernet: Off
+        Status: Updated
+        """)
+
+        // Fold state should be preserved (still expanded)
+        let updatedFoldParent = item.statusBarMenu.items.first { $0.view is FoldableMenuItemView }!
+        let updatedFoldIndex = item.statusBarMenu.index(of: updatedFoldParent)
+        #expect(item.statusBarMenu.items[updatedFoldIndex + 1].isHidden == false)
+    }
+
+    @MainActor @Test func testNestedFold_outerToggleHidesInnerChildren() throws {
+        let item = makeMenuBarItem()
+
+        item._updateMenu(content: """
+        Title
+        ---
+        Outer | fold=true
+        --Inner | fold=true
+        ----Deep A
+        ----Deep B
+        --Regular Child
+        """)
+
+        // Find outer fold parent
+        let outerFold = item.statusBarMenu.items.first { $0.view is FoldableMenuItemView }!
+
+        // Expand outer
+        item.toggleFoldItem(outerFold)
+
+        // Find inner fold parent (now visible)
+        let outerIndex = item.statusBarMenu.index(of: outerFold)
+        let innerFold = item.statusBarMenu.items[outerIndex + 1]
+        #expect(innerFold.view is FoldableMenuItemView)
+        #expect(innerFold.isHidden == false)
+
+        // Expand inner
+        item.toggleFoldItem(innerFold)
+        let innerIndex = item.statusBarMenu.index(of: innerFold)
+        #expect(item.statusBarMenu.items[innerIndex + 1].isHidden == false) // Deep A visible
+
+        // Collapse outer — inner and its children should all be hidden
+        item.toggleFoldItem(outerFold)
+        #expect(innerFold.isHidden == true)
+        // Deep children should also be hidden
+        #expect(item.statusBarMenu.items[innerIndex + 1].isHidden == true)
+    }
+}
+


### PR DESCRIPTION
## Summary

Implements folding/accordion menu items as requested in #412. Plugin authors can add `fold=true` to any item with `--` children to render them as collapsible inline sections instead of traditional submenus.

- **New parameter**: `fold=true` on items with children renders them as accordion sections
- **Click behavior**: Clicking a fold parent toggles children without dismissing the menu (uses `NSMenuItem.view`)
- **Nested folds**: Fold items inside fold items work correctly
- **Live updates**: Fold state preserved across incremental menu updates (streaming + refreshing plugins)
- **Visual**: Uses native SF Symbol chevron (`chevron.right`/`chevron.down`) matching submenu indicator style

### Plugin syntax example
```
Network | fold=true sfimage=wifi
--Wi-Fi: Connected | color=green
--Ethernet: Off | color=gray
--VPN: Off | color=gray
```

### Files changed
- `FoldableMenuItemView.swift` — New custom NSView for fold parents
- `MenuLineParameters.swift` — Added `fold` parameter
- `MenuBarItem.swift` — Fold build/update/toggle logic, incremental header updates
- `SwiftBarTests.swift` — 10 new tests (parameter parsing + fold behavior)

Closes #412

## Test plan
- [ ] Verify `fold=true` renders accordion sections instead of submenus
- [ ] Verify clicking fold item toggles children without closing menu
- [ ] Verify nested folds (fold inside fold) work correctly
- [ ] Verify fold state preserved during live streaming updates
- [ ] Verify items without `fold=true` still render as normal submenus
- [ ] Verify incremental updates patch fold children in-place
- [ ] Run unit tests: `FoldParameterTests`, `FoldMenuItemBuildTests`