### PR TITLE
Fix incremental update misalignment with insert/remove around image items

### DIFF
--- a/SwiftBar/MenuBar/MenuBarItem.swift
+++ b/SwiftBar/MenuBar/MenuBarItem.swift
@@ -704,6 +704,21 @@ extension MenubarItem {
 
         // Diff body items and patch in-place
         let changes = diffMenuNodes(old: currentMenuTree, new: newTree)
+
+        // The positional diff can misalign items when inserts/removes shift indices,
+        // causing item properties (e.g. large images) to be patched onto the wrong
+        // NSMenuItem. This leads to stale layout heights and visual corruption.
+        // Fall back to a full rebuild when the structure changes.
+        let hasStructuralChange = changes.contains { change in
+            if case .insert = change { return true }
+            if case .remove = change { return true }
+            return false
+        }
+        if hasStructuralChange {
+            fullRebuildMenu(content: content)
+            return
+        }
+
         applyDiff(changes, oldTree: currentMenuTree, newTree: newTree, to: statusBarMenu, baseIndex: bodyBaseIndex)
 
         // Update tracking state


### PR DESCRIPTION
## Summary

Fixes #482 — the positional diff in `diffMenuNodes()` misaligns items when inserts or removes shift indices, causing image items to inherit adjacent text as their `attributedTitle` (rendered to the right of the image).

## Changes

When the incremental diff contains structural changes (inserts or removes), fall back to a full menu rebuild instead of patching in-place. The positional diff is only safe when item count is unchanged and items map 1:1 by index.

## Why this approach

The positional diff compares items at the same index. When items are inserted or removed, all items after the change point shift, and `patchMenuItem()` applies the wrong params to existing `NSMenuItem`s. For image items, this means a text title gets set alongside the image, and cached layout heights become stale.

A proper LCS-based diff would fix the root cause but is a larger change. This fallback is safe and preserves the incremental update benefit for the common case (same structure, values change).

## Test plan

- [x] Repro script from #482 no longer shows ghost text beside the image
- [x] Menu still updates live when only values change (no inserts/removes)
- [x] Full rebuild triggers correctly when items appear/disappear