### PR TITLE
Replace positional diff with CollectionDifference-based shape matching

### DIFF
--- a/SwiftBar/MenuBar/MenuDiff.swift
+++ b/SwiftBar/MenuBar/MenuDiff.swift
@@ -16,34 +16,131 @@ enum MenuItemChange: Equatable {
     case remove(oldIndex: Int)
 }
 
-/// Compute the differences between two flat arrays of MenuItemNodes at the same hierarchy level.
+// MARK: - Shape-Based Diffing
+
+/// A wrapper that gives MenuItemNode a shape-based identity for CollectionDifference.
+/// Two nodes with the same shape fingerprint and occurrence index are considered the
+/// "same item" for diffing purposes, even if their content (values, images) changed.
+private struct TaggedNode: Hashable {
+    let fingerprint: ShapeFingerprint
+    let occurrence: Int
+}
+
+/// Compute the differences between two flat arrays of MenuItemNodes using
+/// Swift's CollectionDifference with shape-based identity matching.
 ///
-/// Uses positional comparison: items at the same index are compared directly.
-/// Insertions and removals are detected at the tail. This handles the common case
-/// of same-structure updates (titles/values change but item count stays the same).
+/// Items are matched by structural "shape" (separator, image, font, title prefix)
+/// rather than position, so inserts and removes in the middle of the list correctly
+/// track which items shifted rather than misaligning everything after the change point.
 ///
 /// Removals are returned in reverse index order so the caller can safely remove
 /// items from an NSMenu without invalidating earlier indices.
 func diffMenuNodes(old: [MenuItemNode], new: [MenuItemNode]) -> [MenuItemChange] {
-    var changes: [MenuItemChange] = []
-    let minCount = min(old.count, new.count)
+    let oldTagged = tagNodes(old)
+    let newTagged = tagNodes(new)
 
-    for i in 0 ..< minCount {
-        if old[i] == new[i] {
-            changes.append(.unchanged(oldIndex: i, newIndex: i))
-        } else {
-            changes.append(.update(oldIndex: i, newIndex: i))
+    let diff = newTagged.difference(from: oldTagged).inferringMoves()
+
+    return buildChanges(from: diff, old: old, new: new)
+}
+
+// MARK: - Private Helpers
+
+/// Build tagged node arrays by counting occurrences of each fingerprint.
+private func tagNodes(_ nodes: [MenuItemNode]) -> [TaggedNode] {
+    var counts: [ShapeFingerprint: Int] = [:]
+    return nodes.map { node in
+        let fp = node.shapeFingerprint
+        let occ = counts[fp, default: 0]
+        counts[fp] = occ + 1
+        return TaggedNode(fingerprint: fp, occurrence: occ)
+    }
+}
+
+/// Map CollectionDifference output back to [MenuItemChange].
+private func buildChanges(
+    from diff: CollectionDifference<TaggedNode>,
+    old: [MenuItemNode],
+    new: [MenuItemNode]
+) -> [MenuItemChange] {
+    // Collect pure removes, pure inserts, and moves from the diff.
+    var removedOldIndices = Set<Int>()
+    var insertedNewIndices = Set<Int>()
+    var movedOldToNew: [Int: Int] = [:]
+
+    for change in diff {
+        switch change {
+        case .remove(let offset, _, let associatedWith):
+            if let newOffset = associatedWith {
+                movedOldToNew[offset] = newOffset
+            } else {
+                removedOldIndices.insert(offset)
+            }
+        case .insert(let offset, _, let associatedWith):
+            if associatedWith == nil {
+                insertedNewIndices.insert(offset)
+            }
         }
     }
 
-    for i in minCount ..< new.count {
-        changes.append(.insert(newIndex: i))
+    // Build old→new mapping for stationary items (not moved, removed, or inserted).
+    var oldToNew: [Int: Int] = movedOldToNew
+    let usedOld = removedOldIndices.union(Set(movedOldToNew.keys))
+    let usedNew = insertedNewIndices.union(Set(movedOldToNew.values))
+
+    var oi = 0, ni = 0
+    while oi < old.count && ni < new.count {
+        if usedOld.contains(oi) { oi += 1; continue }
+        if usedNew.contains(ni) { ni += 1; continue }
+        oldToNew[oi] = ni
+        oi += 1; ni += 1
     }
 
-    // Reverse order so removing by index doesn't shift later indices
-    if old.count > minCount {
-        for i in stride(from: old.count - 1, through: minCount, by: -1) {
-            changes.append(.remove(oldIndex: i))
+    // Check that matched items preserve relative order (no true reordering).
+    // If reordered, degrade moved items to remove+insert.
+    let matchedPairs = oldToNew.sorted(by: { $0.key < $1.key })
+    let newIndicesInOldOrder = matchedPairs.map(\.value)
+    let isOrdered = zip(newIndicesInOldOrder, newIndicesInOldOrder.dropFirst()).allSatisfy { $0 < $1 }
+
+    if !isOrdered {
+        for (oldIdx, newIdx) in movedOldToNew {
+            removedOldIndices.insert(oldIdx)
+            insertedNewIndices.insert(newIdx)
+            oldToNew.removeValue(forKey: oldIdx)
+        }
+        // Rebuild stationary mapping without the moved items
+        var soi = 0, sni = 0
+        let sUsedOld = removedOldIndices
+        let sUsedNew = insertedNewIndices
+        oldToNew.removeAll()
+        while soi < old.count && sni < new.count {
+            if sUsedOld.contains(soi) { soi += 1; continue }
+            if sUsedNew.contains(sni) { sni += 1; continue }
+            oldToNew[soi] = sni
+            soi += 1; sni += 1
+        }
+    }
+
+    // Build the reverse map for fast lookup
+    var newToOld: [Int: Int] = [:]
+    for (o, n) in oldToNew { newToOld[n] = o }
+
+    // Assemble result: removals in reverse order first, then updates/inserts forward.
+    var changes: [MenuItemChange] = []
+
+    for oldIdx in removedOldIndices.sorted(by: >) {
+        changes.append(.remove(oldIndex: oldIdx))
+    }
+
+    for ni in 0 ..< new.count {
+        if insertedNewIndices.contains(ni) {
+            changes.append(.insert(newIndex: ni))
+        } else if let oi = newToOld[ni] {
+            if old[oi] == new[ni] {
+                changes.append(.unchanged(oldIndex: oi, newIndex: ni))
+            } else {
+                changes.append(.update(oldIndex: oi, newIndex: ni))
+            }
         }
     }
 

--- a/SwiftBar/MenuBar/MenuItemNode.swift
+++ b/SwiftBar/MenuBar/MenuItemNode.swift
@@ -17,6 +17,56 @@ struct MenuItemNode: Equatable {
     }
 }
 
+// MARK: - Shape Fingerprint
+
+/// A structural fingerprint that identifies the "role" of a menu item,
+/// independent of volatile content like numbers, colors, or image data.
+/// Used by the diff algorithm to match items across position shifts.
+struct ShapeFingerprint: Hashable {
+    let isSeparator: Bool
+    let hasImage: Bool
+    let fontName: String?
+    let hasFold: Bool
+    let titleKey: String
+    let hasChildren: Bool
+}
+
+extension MenuItemNode {
+    /// Compute a shape fingerprint for diffing. Two nodes with the same fingerprint
+    /// are considered the "same item" even if their content changed.
+    var shapeFingerprint: ShapeFingerprint {
+        if isSeparator {
+            return ShapeFingerprint(isSeparator: true, hasImage: false, fontName: nil, hasFold: false, titleKey: "", hasChildren: false)
+        }
+        let params = MenuLineParameters(line: workingLine)
+        return ShapeFingerprint(
+            isSeparator: false,
+            hasImage: params.params["image"] != nil || params.params["templateimage"] != nil,
+            fontName: params.font,
+            hasFold: params.fold,
+            titleKey: Self.extractTitleKey(from: params.title),
+            hasChildren: !children.isEmpty
+        )
+    }
+
+    /// Extract the stable "key" portion of a title.
+    /// "Battery: 78% ████████░░" → "Battery:"
+    /// "Climate: On  Set: 72°F" → "Climate:"
+    /// "Home" → "Home"
+    /// "" (image-only) → ""
+    static func extractTitleKey(from title: String) -> String {
+        let trimmed = title.trimmingCharacters(in: .whitespaces)
+        if trimmed.isEmpty { return "" }
+        // If title contains a colon, take everything up to and including it
+        if let colonIdx = trimmed.firstIndex(of: ":") {
+            return String(trimmed[...colonIdx])
+        }
+        // Otherwise take the first word
+        let firstWord = trimmed.prefix(while: { !$0.isWhitespace })
+        return String(firstWord)
+    }
+}
+
 // MARK: - Line Parsing
 
 extension MenuItemNode {

--- a/SwiftBar/MenuBar/MenuItemNode.swift
+++ b/SwiftBar/MenuBar/MenuItemNode.swift
@@ -26,7 +26,6 @@ struct ShapeFingerprint: Hashable {
     let isSeparator: Bool
     let hasImage: Bool
     let fontName: String?
-    let hasFold: Bool
     let titleKey: String
     let hasChildren: Bool
 }
@@ -36,14 +35,13 @@ extension MenuItemNode {
     /// are considered the "same item" even if their content changed.
     var shapeFingerprint: ShapeFingerprint {
         if isSeparator {
-            return ShapeFingerprint(isSeparator: true, hasImage: false, fontName: nil, hasFold: false, titleKey: "", hasChildren: false)
+            return ShapeFingerprint(isSeparator: true, hasImage: false, fontName: nil, titleKey: "", hasChildren: false)
         }
         let params = MenuLineParameters(line: workingLine)
         return ShapeFingerprint(
             isSeparator: false,
             hasImage: params.params["image"] != nil || params.params["templateimage"] != nil,
             fontName: params.font,
-            hasFold: params.fold,
             titleKey: Self.extractTitleKey(from: params.title),
             hasChildren: !children.isEmpty
         )

--- a/SwiftBarTests/SwiftBarTests.swift
+++ b/SwiftBarTests/SwiftBarTests.swift
@@ -2082,10 +2082,10 @@ struct MenuDiffTests {
         let changes = diffMenuNodes(old: old, new: new)
 
         #expect(changes.count == 3)
-        #expect(changes[0] == .unchanged(oldIndex: 0, newIndex: 0))
-        // Removals in reverse index order
-        #expect(changes[1] == .remove(oldIndex: 2))
-        #expect(changes[2] == .remove(oldIndex: 1))
+        // Removals come first in reverse index order, then non-removals
+        #expect(changes[0] == .remove(oldIndex: 2))
+        #expect(changes[1] == .remove(oldIndex: 1))
+        #expect(changes[2] == .unchanged(oldIndex: 0, newIndex: 0))
     }
 
     @Test func testDiff_allChanged() throws {


### PR DESCRIPTION
## Summary

Alternative fix for #482 — replaces the naive positional diff with Swift's `CollectionDifference` using shape-based identity matching. This correctly handles mid-list inserts and removes without misaligning item properties.

See #483 for the simpler fallback approach (Option 1).

## How it works

Each `MenuItemNode` gets a `ShapeFingerprint` that captures its structural role:
- `isSeparator` — separators match other separators
- `hasImage` — image-only lines are distinct from text
- `fontName` — monospace lines (e.g. `font=Menlo`) are distinct
- `titleKey` — stable prefix up to first `:` or first word ("Battery:", "Climate:", "Home")
- `hasChildren` / `hasFold` — structural distinctions

An occurrence counter disambiguates duplicates (e.g. multiple separators). `CollectionDifference.inferringMoves()` uses these tagged nodes to correctly track items across position shifts.

## Pros / Cons vs Option 1 (#483)

### Option 1: Full rebuild on structural change (#483)
**Pros:**
- Minimal code change (~15 lines)
- Zero risk of new edge cases
- Easy to review and reason about

**Cons:**
- Loses live menu updates when items appear/disappear (menu flickers on rebuild)
- Fold expansion state lost on structural changes
- Webview state destroyed on structural changes
- Doesn't fulfill the original goal of #467 for the insert/remove case

### Option 2: CollectionDifference shape matching (this PR)
**Pros:**
- Menu stays fully live during all updates — no flicker on insert/remove
- Fold expansion state preserved across structural changes
- Webview state preserved
- Fulfills the original intent of #467 for all cases
- Uses Swift's battle-tested LCS algorithm, not a custom diff

**Cons:**
- More code (~150 lines added)
- Shape fingerprint heuristics may need tuning for edge cases (e.g. two items with identical shapes)
- Falls back to remove+insert for true reordering (rare for plugins)

## Files changed

- `MenuItemNode.swift` — Added `ShapeFingerprint` struct, `shapeFingerprint` computed property, `extractTitleKey()` helper
- `MenuDiff.swift` — Replaced `diffMenuNodes()` with CollectionDifference-based implementation, added `TaggedNode` wrapper

## Test plan

- [x] Repro script from #482 — no ghost text beside image with menu open
- [x] Values-only updates still patch in-place (no rebuild)
- [x] Insert/remove correctly tracks shifted items
- [ ] Fold sections preserve expansion state across structural changes
- [ ] Existing SwiftBar tests pass