### PR TITLE
Fix #488: re-arm plugin refresh timer after cancellation

### DIFF
--- a/SwiftBar/Plugin/ExecutablePlugin.swift
+++ b/SwiftBar/Plugin/ExecutablePlugin.swift
@@ -50,6 +50,8 @@ class ExecutablePlugin: TimerArmingPlugin {
     var cronTimer: Timer?
 
     var cancellable: Set<AnyCancellable> = []
+    var timerGeneration: UInt = 0
+    var timerArmingEnabled = true
 
     let prefs = PreferencesStore.shared
 
@@ -100,11 +102,13 @@ class ExecutablePlugin: TimerArmingPlugin {
 
     func disable() {
         lastState = .Disabled
+        stopTimerArming()
         disableTimer()
         prefs.disabledPlugins.append(id)
     }
 
     func terminate() {
+        stopTimerArming()
         disableTimer()
     }
 
@@ -114,6 +118,7 @@ class ExecutablePlugin: TimerArmingPlugin {
     }
 
     func start() {
+        beginTimerArmingCycle()
         // Check if this is a wake from sleep event by checking if lastUpdated exists
         if lastUpdated != nil {
             // Handle wake from sleep differently - check if it's time to update based on schedule
@@ -150,6 +155,7 @@ class ExecutablePlugin: TimerArmingPlugin {
         }
         os_log("Requesting manual refresh for plugin\n%{public}@", log: Log.plugin, description)
         debugInfo.addEvent(type: .PluginRefresh, value: "Requesting manual refresh")
+        beginTimerArmingCycle()
         disableTimer()
         operation?.cancel()
 

--- a/SwiftBar/Plugin/PackagedPlugin.swift
+++ b/SwiftBar/Plugin/PackagedPlugin.swift
@@ -53,6 +53,8 @@ class PackagedPlugin: TimerArmingPlugin {
     var cronTimer: Timer?
 
     var cancellable: Set<AnyCancellable> = []
+    var timerGeneration: UInt = 0
+    var timerArmingEnabled = true
 
     let prefs = PreferencesStore.shared
 
@@ -184,11 +186,13 @@ class PackagedPlugin: TimerArmingPlugin {
 
     func disable() {
         lastState = .Disabled
+        stopTimerArming()
         disableTimer()
         prefs.disabledPlugins.append(id)
     }
 
     func terminate() {
+        stopTimerArming()
         disableTimer()
     }
 
@@ -198,6 +202,7 @@ class PackagedPlugin: TimerArmingPlugin {
     }
 
     func start() {
+        beginTimerArmingCycle()
         if lastUpdated != nil {
             if let metadata, metadata.nextDate != nil {
                 refreshPluginMetadata()
@@ -226,6 +231,7 @@ class PackagedPlugin: TimerArmingPlugin {
         }
         os_log("Requesting refresh for packaged plugin\n%{public}@", log: Log.plugin, description)
         debugInfo.addEvent(type: .PluginRefresh, value: "Requesting refresh")
+        beginTimerArmingCycle()
         disableTimer()
         operation?.cancel()
 

--- a/SwiftBar/Plugin/Plugin.swift
+++ b/SwiftBar/Plugin/Plugin.swift
@@ -96,7 +96,21 @@ protocol Plugin: AnyObject {
 /// Conforming types can be generically re-armed by `RunPluginOperation`
 /// after each invocation, without the caller knowing the concrete plugin type.
 protocol TimerArmingPlugin: Plugin {
+    var timerGeneration: UInt { get set }
+    var timerArmingEnabled: Bool { get set }
     func enableTimer()
+}
+
+extension TimerArmingPlugin {
+    func beginTimerArmingCycle() {
+        timerArmingEnabled = true
+        timerGeneration &+= 1
+    }
+
+    func stopTimerArming() {
+        timerArmingEnabled = false
+        timerGeneration &+= 1
+    }
 }
 
 extension Plugin {

--- a/SwiftBar/Plugin/ShortcutPlugin.swift
+++ b/SwiftBar/Plugin/ShortcutPlugin.swift
@@ -65,6 +65,8 @@ class ShortcutPlugin: TimerArmingPlugin, Identifiable, ObservableObject {
     }
 
     var cancellable: Set<AnyCancellable> = []
+    var timerGeneration: UInt = 0
+    var timerArmingEnabled = true
 
     let shortcutsManager = ShortcutsManager.shared
 
@@ -108,6 +110,7 @@ class ShortcutPlugin: TimerArmingPlugin, Identifiable, ObservableObject {
         }
         os_log("Requesting manual refresh for plugin\n%{public}@", log: Log.plugin, description)
         debugInfo.addEvent(type: .PluginRefresh, value: "Requesting manual refresh")
+        beginTimerArmingCycle()
         disableTimer()
         operation?.cancel()
 
@@ -123,6 +126,7 @@ class ShortcutPlugin: TimerArmingPlugin, Identifiable, ObservableObject {
 
     func disable() {
         lastState = .Disabled
+        stopTimerArming()
         disableTimer()
         prefs.disabledPlugins.append(id)
     }
@@ -132,6 +136,7 @@ class ShortcutPlugin: TimerArmingPlugin, Identifiable, ObservableObject {
     }
 
     func terminate() {
+        stopTimerArming()
         disableTimer()
     }
 

--- a/SwiftBar/Utility/PluginUtilities.swift
+++ b/SwiftBar/Utility/PluginUtilities.swift
@@ -25,18 +25,47 @@ func parseRefreshInterval(intervalStr: String, baseUpdateinterval: Double) -> Do
 
 final class RunPluginOperation<T: Plugin>: Operation {
     weak var plugin: T?
+    private let scheduledTimerGeneration: UInt?
+    private let timerRearmLock = NSLock()
+    private var timerRearmHandled = false
 
     init(plugin: T) {
         self.plugin = plugin
+        scheduledTimerGeneration = (plugin as? TimerArmingPlugin)?.timerGeneration
         super.init()
     }
 
+    override func cancel() {
+        super.cancel()
+        if !isExecuting {
+            rearmTimerIfCurrent()
+        }
+    }
+
     override func main() {
+        defer { rearmTimerIfCurrent() }
         guard !isCancelled else { return }
         let result = plugin?.invoke()
         // Check again after invoke - operation may have been cancelled while script was running
         guard !isCancelled else { return }
         plugin?.content = result
-        (plugin as? TimerArmingPlugin)?.enableTimer()
+    }
+
+    private func rearmTimerIfCurrent() {
+        timerRearmLock.lock()
+        guard !timerRearmHandled else {
+            timerRearmLock.unlock()
+            return
+        }
+        timerRearmHandled = true
+        timerRearmLock.unlock()
+
+        guard let timerPlugin = plugin as? TimerArmingPlugin,
+              timerPlugin.timerArmingEnabled,
+              timerPlugin.timerGeneration == scheduledTimerGeneration
+        else {
+            return
+        }
+        timerPlugin.enableTimer()
     }
 }

--- a/SwiftBarTests/SwiftBarTests.swift
+++ b/SwiftBarTests/SwiftBarTests.swift
@@ -62,6 +62,8 @@ final class TimedTestPlugin: TimerArmingPlugin {
     var debugInfo = PluginDebugInfo()
     var refreshEnv: [String: String] = [:]
     var enableTimerCallCount = 0
+    var timerGeneration: UInt = 0
+    var timerArmingEnabled = true
     let invokeResult: String?
 
     init(id: PluginID, file: String, invokeResult: String?) {
@@ -150,13 +152,63 @@ struct SwiftBarTests {
         #expect(shouldLoadPluginFile(at: symlinkURL, makePluginExecutable: false))
     }
 
-    @Test func testRunPluginOperation_rearmsTimersForTimerArmingPlugins() async throws {
+    @Test func testRunPluginOperation_rearmsTimersForTimerArmingPlugins() {
         let plugin = TimedTestPlugin(id: "timed-plugin", file: "/tmp/timed.5s.sh", invokeResult: "updated")
+        let operation = RunPluginOperation(plugin: plugin)
+        let queue = OperationQueue()
 
-        RunPluginOperation(plugin: plugin).main()
+        #expect(plugin.enableTimerCallCount == 0)
+        queue.addOperations([operation], waitUntilFinished: true)
 
         #expect(plugin.content == "updated")
         #expect(plugin.enableTimerCallCount == 1)
+    }
+
+    @Test func testRunPluginOperation_rearmsTimerWhenCancelledBeforeMain() {
+        // Issue #488: refresh() disables the timer before scheduling a new
+        // RunPluginOperation. If that operation is cancelled before main() can
+        // re-arm the timer (e.g. pluginInvokeQueue.cancelAllOperations()), the
+        // plugin would be left without a scheduled refresh and stay dormant
+        // until the SwiftBar process is restarted.
+        let plugin = TimedTestPlugin(id: "timed-plugin", file: "/tmp/timed.5s.sh", invokeResult: "updated")
+        let op = RunPluginOperation(plugin: plugin)
+        let queue = OperationQueue()
+        queue.isSuspended = true
+        queue.addOperation(op)
+        op.cancel()
+        queue.isSuspended = false
+        queue.waitUntilAllOperationsAreFinished()
+
+        #expect(plugin.content == nil)
+        #expect(plugin.enableTimerCallCount == 1)
+    }
+
+    @Test func testRunPluginOperation_doesNotRearmAfterTimerCycleStops() {
+        let plugin = TimedTestPlugin(id: "timed-plugin", file: "/tmp/timed.5s.sh", invokeResult: "updated")
+        let operation = RunPluginOperation(plugin: plugin)
+        let queue = OperationQueue()
+        queue.isSuspended = true
+        queue.addOperation(operation)
+
+        plugin.stopTimerArming()
+        operation.cancel()
+        queue.isSuspended = false
+        queue.waitUntilAllOperationsAreFinished()
+
+        #expect(plugin.content == nil)
+        #expect(plugin.enableTimerCallCount == 0)
+    }
+
+    @Test func testRunPluginOperation_doesNotRearmStaleTimerGeneration() {
+        let plugin = TimedTestPlugin(id: "timed-plugin", file: "/tmp/timed.5s.sh", invokeResult: "updated")
+        let operation = RunPluginOperation(plugin: plugin)
+        let queue = OperationQueue()
+
+        plugin.beginTimerArmingCycle()
+        queue.addOperations([operation], waitUntilFinished: true)
+
+        #expect(plugin.content == "updated")
+        #expect(plugin.enableTimerCallCount == 0)
     }
 
     @Test func testMenuItemActionKinds_includeHrefAndRefreshTogether() async throws {
@@ -795,7 +847,7 @@ struct SwiftBarIntegrationTests {
         #expect(loadCallCount == 0)
     }
 
-    @Test func testSyncFilePlugins_keepsSymlinkedPackagedPluginMatchedByBundlePath() async throws {
+    @Test func testSyncFilePlugins_keepsSymlinkedPackagedPluginMatchedByBundlePath() throws {
         let tempDirectory = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
         try FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: tempDirectory) }
@@ -812,6 +864,7 @@ struct SwiftBarIntegrationTests {
 
         let existingPlugin = try #require(PackagedPlugin(packageDirectory: symlinkedPackageURL))
         existingPlugin.operation?.cancel()
+        existingPlugin.operation?.waitUntilFinished()
         defer { existingPlugin.terminate() }
         let packageState = try #require(pluginFileState(for: symlinkedPackageURL))
         let packageSyncPath = pluginSyncPath(for: symlinkedPackageURL)
@@ -838,7 +891,7 @@ struct SwiftBarIntegrationTests {
         #expect(loadCallCount == 0)
     }
 
-    @Test func testPackagedPlugin_symlinkPreservesAliasEntryPointAndSyncPath() async throws {
+    @Test func testPackagedPlugin_symlinkPreservesAliasEntryPointAndSyncPath() throws {
         let tempDirectory = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
         try FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: tempDirectory) }
@@ -855,6 +908,7 @@ struct SwiftBarIntegrationTests {
 
         let plugin = try #require(PackagedPlugin(packageDirectory: packageAliasURL))
         plugin.operation?.cancel()
+        plugin.operation?.waitUntilFinished()
         defer { plugin.terminate() }
 
         #expect(plugin.mainExecutable.path == packageAliasURL.appendingPathComponent("plugin.sh").path)
@@ -1019,7 +1073,7 @@ struct SwiftBarIntegrationTests {
         #expect(manager.loadPlugin(fileURL: packageURL) == nil)
     }
 
-    @Test func testPackagedPlugin_keepsStreamableMetadataOnExecutableCodePath() async throws {
+    @Test func testPackagedPlugin_keepsStreamableMetadataOnExecutableCodePath() throws {
         let tempDirectory = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
         try FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: tempDirectory) }
@@ -1037,6 +1091,7 @@ struct SwiftBarIntegrationTests {
 
         let plugin = try #require(PackagedPlugin(packageDirectory: packageURL))
         plugin.operation?.cancel()
+        plugin.operation?.waitUntilFinished()
         plugin.terminate()
 
         #expect(plugin.type == .Executable)


### PR DESCRIPTION
## Summary

Related to #488.

The reported image/memory issue was a stopped refresh schedule: cancellation could prevent a timer-backed plugin from ever scheduling its next run.

## Fix

- Track a timer generation for each timer-backed plugin.
- Re-arm the current operation after normal completion or cancellation before execution.
- Prevent stale, disabled, or terminated operations from restoring timers.
- Apply the lifecycle to executable, packaged, and Shortcut plugins.
- Wait for canceled packaged-plugin test processes before fixture teardown.

The unrelated timeout and diagnostics work has been removed from this PR.

## Validation

- [x] Focused timer and packaged-plugin suites: 75/75
- [x] Full suite: 166/166
- [x] `codex review --base origin/main`: no actionable findings
- [ ] Reporter validation with the original `homeweather.2m.py` scenario
