### PR TITLE
Fix About panel foreground activation

### DIFF
--- a/SwiftBar/AppShared.swift
+++ b/SwiftBar/AppShared.swift
@@ -189,6 +189,11 @@ class AppShared: NSObject {
     }
 
     public static func showAbout() {
+        if #available(macOS 14.0, *) {
+            NSApp.activate()
+        } else {
+            NSApp.activate(ignoringOtherApps: true)
+        }
         NSApp.orderFrontStandardAboutPanel()
     }
 


### PR DESCRIPTION
Fixes #493.

## What changed

Activate SwiftBar before presenting the standard About panel. Use `NSApplication.activate()` on macOS 14 and later, with `activate(ignoringOtherApps:)` for older supported releases.

## Why

SwiftBar runs as an accessory app. Ordering the About panel to the front did not activate the app, so another foreground application could remain above it.

## Impact

Choosing About SwiftBar now brings the standard About panel to the foreground.

## Validation

- 166 tests passed on macOS 27
- Signed Debug build 578 compiled with Xcode 27 and `MACOSX_DEPLOYMENT_TARGET=12.0`
- Manual smoke test passed with Finder in front before opening About SwiftBar
- Confirmed the About panel appeared in the foreground and showed the 2026 copyright
- `codex review --uncommitted` reported no findings
- `git diff --check origin/main...HEAD` passed
