### PR TITLE
Require macOS 12 for Xcode 27 builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ or Install with Homebrew
 brew install swiftbar
 ```
 
-Runs on macOS Catalina (10.15) and up.
+Runs on macOS Monterey (12) and later.
 
 ## ...or build it from source
 - Clone or download a copy of this repository

--- a/SwiftBar.xcodeproj/project.pbxproj
+++ b/SwiftBar.xcodeproj/project.pbxproj
@@ -883,7 +883,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MARKETING_VERSION = 2.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ameba.SwiftBar;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -912,7 +912,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MARKETING_VERSION = 2.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ameba.SwiftBar;
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
## What changed

- Raise the SwiftBar target deployment setting from macOS 11 to macOS 12 for Debug and Release.
- Update the README requirement to macOS Monterey 12 and later.

## Why

Xcode 27 supports deployment targets from macOS 12 onward. The existing macOS 11 target prevents a normal build and can surface as a module compatibility error when package products are compiled for macOS 12.

## Impact

SwiftBar builds with Xcode 27 without a command-line deployment-target override. New builds no longer support macOS Big Sur 11 or earlier.

## Validation

- 166 tests passed on macOS 27; 0 failed, skipped, or runtime warnings
- Debug and Release builds passed without a deployment-target override
- Signed Debug build passed strict code-sign verification and launched successfully
- Debug and Release build settings resolve to `MACOSX_DEPLOYMENT_TARGET = 12.0`
- Project file passed `plutil -lint`
- `git diff --check` passed
- `codex review --uncommitted` reported no remaining findings

Clean compilation still reports the repository's existing Swift and metadata warnings; this patch adds none.