### PR TITLE
fix(menu): refresh submenus after incremental updates

### DIFF
--- a/SwiftBar/MenuBar/MenuBarItem.swift
+++ b/SwiftBar/MenuBar/MenuBarItem.swift
@@ -974,7 +974,13 @@ extension MenubarItem {
     /// Patch an existing NSMenuItem's visible properties to match new parameters.
     private func patchMenuItem(_ item: NSMenuItem, with params: MenuLineParameters) {
         let needsAction = params.hasAction || params.color != nil
-        item.action = needsAction ? #selector(perfomMenutItemAction) : nil
+        item.action = if needsAction {
+            #selector(perfomMenutItemAction)
+        } else if params.fold {
+            #selector(toggleFoldItem(_:))
+        } else {
+            nil
+        }
         item.representedObject = params
 
         let title = atributedTitle(with: params)
@@ -1190,7 +1196,7 @@ extension MenubarItem {
     }
 
     /// Toggle the fold state of a menu item.
-    func toggleFoldItem(_ item: NSMenuItem) {
+    @objc func toggleFoldItem(_ item: NSMenuItem) {
         let key = ObjectIdentifier(item)
         let wasExpanded = expandedFoldItems.contains(key)
         if let foldView = item.view as? FoldableMenuItemView {
@@ -1454,8 +1460,15 @@ extension MenubarItem {
         // Assign action when color is set so macOS renders the item as enabled,
         // allowing the custom color to display instead of the disabled grey.
         let needsAction = params.hasAction || params.color != nil
+        let action: Selector? = if needsAction {
+            #selector(perfomMenutItemAction)
+        } else if params.fold {
+            #selector(toggleFoldItem(_:))
+        } else {
+            nil
+        }
         let item = NSMenuItem(title: params.title,
-                              action: needsAction ? #selector(perfomMenutItemAction) : nil,
+                              action: action,
                               keyEquivalent: "")
         item.representedObject = params
         let title = atributedTitle(with: params)

--- a/SwiftBar/MenuBar/MenuBarItem.swift
+++ b/SwiftBar/MenuBar/MenuBarItem.swift
@@ -27,7 +27,7 @@ class MenubarItem: NSObject {
         return item
     }()
 
-    let statusBarMenu = NSMenu(title: "")
+    let statusBarMenu: NSMenu
     let titleCylleInterval: Double = 5
     var contentUpdateCancellable: AnyCancellable?
     var titleCycleCancellable: AnyCancellable?
@@ -102,8 +102,9 @@ class MenubarItem: NSObject {
 
     lazy var menuUpdateQueue: OperationQueue = delegate.pluginManager.menuUpdateQueue
 
-    init(title: String, plugin: Plugin? = nil, visibilityDidChange: ((Bool) -> Void)? = nil) {
+    init(title: String, plugin: Plugin? = nil, visibilityDidChange: ((Bool) -> Void)? = nil, statusBarMenu: NSMenu = NSMenu(title: "")) {
         self.visibilityDidChange = visibilityDidChange
+        self.statusBarMenu = statusBarMenu
         super.init()
         barItem.button?.action = #selector(barItemClicked)
         barItem.button?.target = self
@@ -1049,6 +1050,7 @@ extension MenubarItem {
         guard isOpen else { return }
         hotKeys.forEach { $0.isPaused = true }
         updateOpenMenuItemVisibility()
+        statusBarMenu.update()
     }
 
     private func updateOpenMenuItemVisibility() {

--- a/SwiftBarTests/SwiftBarTests.swift
+++ b/SwiftBarTests/SwiftBarTests.swift
@@ -1808,12 +1808,23 @@ struct RefreshReasonContentSyncTests {
     }
 }
 
-private final class UpdateTrackingMenu: NSMenu {
-    var updateCallCount = 0
+/// Models the presentation state AppKit keeps separately from the NSMenu tree
+/// while tracking. A structural removal makes the displayed parents stale;
+/// update() reconciles regular submenu parents, while fold parents still need
+/// an actionable target for AppKit validation to enable them.
+private final class StalePresentationMenu: NSMenu {
+    override func removeItem(at index: Int) {
+        super.removeItem(at: index)
+        for item in items where item.submenu != nil || item.view is FoldableMenuItemView {
+            item.isEnabled = false
+        }
+    }
 
     override func update() {
-        updateCallCount += 1
         super.update()
+        for item in items where item.submenu != nil {
+            item.isEnabled = true
+        }
     }
 }
 
@@ -2007,23 +2018,22 @@ struct MenubarItemIncrementalUpdateTests {
         #expect(item.hotKeys.allSatisfy { $0.isPaused })
     }
 
-    @MainActor @Test func testIncrementalUpdate_keepsSubmenuParentsEnabledAfterMiddleRemoval() throws {
-        let trackingMenu = UpdateTrackingMenu(title: "")
-        let item = makeMenuBarItem(statusBarMenu: trackingMenu)
+    @MainActor @Test func testIncrementalUpdate_revalidatesPresentedSubmenuAndFoldParentsAfterMiddleRemoval() throws {
+        let presentationMenu = StalePresentationMenu(title: "")
+        let item = makeMenuBarItem(statusBarMenu: presentationMenu)
 
         item._updateMenu(content: """
         Title
         ---
-        Formulas (5):
         alpha
         --Run | refresh=true
+        Network | fold=true
+        --Wi-Fi: Connected
         beta
         --Run | refresh=true
         gamma
         --Run | refresh=true
         delta
-        --Run | refresh=true
-        epsilon
         --Run | refresh=true
         """)
 
@@ -2032,24 +2042,32 @@ struct MenubarItemIncrementalUpdateTests {
         item._updateMenu(content: """
         Title
         ---
-        Formulas (4):
         alpha
         --Run | refresh=true
+        Network | fold=true
+        --Wi-Fi: Connected
         beta
         --Run | refresh=true
         delta
         --Run | refresh=true
-        epsilon
-        --Run | refresh=true
         """)
 
-        #expect(trackingMenu.updateCallCount > 0)
-
-        for title in ["alpha", "beta", "delta", "epsilon"] {
+        for title in ["alpha", "beta", "delta"] {
             let formulaItem = try #require(item.statusBarMenu.items.first { $0.title == title })
             #expect(formulaItem.submenu != nil)
             #expect(formulaItem.isEnabled)
         }
+
+        let foldParent = try #require(item.statusBarMenu.items.first { $0.view is FoldableMenuItemView })
+        let foldIndex = item.statusBarMenu.index(of: foldParent)
+        let foldChild = item.statusBarMenu.items[foldIndex + 1]
+
+        #expect(foldParent.action == #selector(MenubarItem.toggleFoldItem(_:)))
+        #expect(foldParent.target === item)
+        #expect(foldParent.isEnabled)
+        #expect(foldChild.isHidden)
+        #expect(NSApp.sendAction(try #require(foldParent.action), to: foldParent.target, from: foldParent))
+        #expect(!foldChild.isHidden)
     }
 }
 
@@ -2516,7 +2534,7 @@ struct FoldMenuItemBuildTests {
         #expect(childItem2.attributedTitle?.string == "Ethernet: Off")
     }
 
-    @MainActor @Test func testMenuWillOpen_keepsActionlessFoldParentEnabled() throws {
+    @MainActor @Test func testMenuWillOpen_revalidatesFoldParentAction() throws {
         let item = makeMenuBarItem()
 
         item._updateMenu(content: """
@@ -2527,8 +2545,11 @@ struct FoldMenuItemBuildTests {
         """)
 
         let foldParent = try #require(item.statusBarMenu.items.first { $0.view is FoldableMenuItemView })
+        foldParent.isEnabled = false
         item.menuWillOpen(item.statusBarMenu)
 
+        #expect(foldParent.action == #selector(MenubarItem.toggleFoldItem(_:)))
+        #expect(foldParent.target === item)
         #expect(foldParent.isEnabled)
     }
 

--- a/SwiftBarTests/SwiftBarTests.swift
+++ b/SwiftBarTests/SwiftBarTests.swift
@@ -2516,6 +2516,22 @@ struct FoldMenuItemBuildTests {
         #expect(childItem2.attributedTitle?.string == "Ethernet: Off")
     }
 
+    @MainActor @Test func testMenuWillOpen_keepsActionlessFoldParentEnabled() throws {
+        let item = makeMenuBarItem()
+
+        item._updateMenu(content: """
+        Title
+        ---
+        Network | fold=true
+        --Wi-Fi: Connected
+        """)
+
+        let foldParent = try #require(item.statusBarMenu.items.first { $0.view is FoldableMenuItemView })
+        item.menuWillOpen(item.statusBarMenu)
+
+        #expect(foldParent.isEnabled)
+    }
+
     @MainActor @Test func testFullBuild_foldItemExpandsOnToggle() throws {
         let item = makeMenuBarItem()
 

--- a/SwiftBarTests/SwiftBarTests.swift
+++ b/SwiftBarTests/SwiftBarTests.swift
@@ -1808,11 +1808,20 @@ struct RefreshReasonContentSyncTests {
     }
 }
 
+private final class UpdateTrackingMenu: NSMenu {
+    var updateCallCount = 0
+
+    override func update() {
+        updateCallCount += 1
+        super.update()
+    }
+}
+
 struct MenubarItemIncrementalUpdateTests {
     @MainActor
-    private func makeMenuBarItem() -> MenubarItem {
+    private func makeMenuBarItem(statusBarMenu: NSMenu = NSMenu(title: "")) -> MenubarItem {
         let plugin = TestPlugin(id: "test-plugin", file: "/tmp/test-plugin.5s.sh", content: nil, lastState: .Success)
-        let item = MenubarItem(title: "Test")
+        let item = MenubarItem(title: "Test", statusBarMenu: statusBarMenu)
         item.plugin = plugin
         item.statusBarMenu.delegate = item
         return item
@@ -1996,6 +2005,51 @@ struct MenubarItemIncrementalUpdateTests {
 
         #expect(item.hotKeys.count == 1)
         #expect(item.hotKeys.allSatisfy { $0.isPaused })
+    }
+
+    @MainActor @Test func testIncrementalUpdate_keepsSubmenuParentsEnabledAfterMiddleRemoval() throws {
+        let trackingMenu = UpdateTrackingMenu(title: "")
+        let item = makeMenuBarItem(statusBarMenu: trackingMenu)
+
+        item._updateMenu(content: """
+        Title
+        ---
+        Formulas (5):
+        alpha
+        --Run | refresh=true
+        beta
+        --Run | refresh=true
+        gamma
+        --Run | refresh=true
+        delta
+        --Run | refresh=true
+        epsilon
+        --Run | refresh=true
+        """)
+
+        item.hotkeyTrigger = true
+        item.menuWillOpen(item.statusBarMenu)
+        item._updateMenu(content: """
+        Title
+        ---
+        Formulas (4):
+        alpha
+        --Run | refresh=true
+        beta
+        --Run | refresh=true
+        delta
+        --Run | refresh=true
+        epsilon
+        --Run | refresh=true
+        """)
+
+        #expect(trackingMenu.updateCallCount > 0)
+
+        for title in ["alpha", "beta", "delta", "epsilon"] {
+            let formulaItem = try #require(item.statusBarMenu.items.first { $0.title == title })
+            #expect(formulaItem.submenu != nil)
+            #expect(formulaItem.isEnabled)
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- revalidate the live `NSMenu` after an open-menu incremental diff
- keep actionless fold parents actionable so AppKit validation does not disable their custom rows
- test final presentation behavior for fold and non-fold submenu parents, including open-menu lifecycle ordering

## Root cause

The parsed menu tree remained correct after a structural incremental update, but AppKit retained separate stale presentation/validation state while tracking the menu. Calling `NSMenu.update()` after the diff reconciles regular submenu parents. Fold parents use a custom view and previously had no action, so the same AppKit validation pass disabled them; assigning the existing fold-toggle action preserves both validation and behavior.

## Reproduction

On the pre-fix `b0c09d3` baseline, a SwiftBar app-hosted test opened a real menu with `NSMenu.popUp`, then removed the middle `gamma` submenu during the native tracking loop. The public model reported all surviving parents as enabled with submenus, while AppKit logged:

```text
[Menu_Tracking] didChangeKeyEquivalentModifierMask: rep returned item view with wrong item:
  index=2
  expected item = <... Formulas (4): ...>
  actual item = <... Formulas (5): ...>
```

This reproduces the stale live presentation independently of parsed tree state. macOS did not expose the transient status menu as a useful accessibility subtree, so I did not treat synthetic pointer/keyboard automation as visual proof.

## Validation

- focused fold + incremental suites: 20 passed, 0 failed
- full SwiftBar suite: 181 passed, 0 failed, 0 skipped
- mutation without `statusBarMenu.update()`: 2 focused failures
- mutation that reapplies open-menu state before the diff: 2/8 failures
- mutation without the fold action in build/patch paths: 2 focused failures
- final Debug app launched with an isolated 1-second submenu/fold plugin and refreshed repeatedly without a crash
- all three commits are signed and reported `verified: true` by GitHub

Focused command:

```sh
xcodebuild test -quiet -project SwiftBar.xcodeproj -scheme SwiftBar \
  -destination 'platform=macOS' \
  -derivedDataPath DerivedData/PR499/final \
  -resultBundlePath DerivedData/PR499/focused-strengthened.xcresult \
  -parallel-testing-enabled NO \
  -only-testing:SwiftBarTests/MenubarItemIncrementalUpdateTests \
  -only-testing:SwiftBarTests/FoldMenuItemBuildTests \
  CODE_SIGNING_ALLOWED=NO
```

Full command:

```sh
xcodebuild test -quiet -project SwiftBar.xcodeproj -scheme SwiftBar \
  -destination 'platform=macOS' \
  -derivedDataPath DerivedData/PR499/full \
  -resultBundlePath DerivedData/PR499/full.xcresult \
  -parallel-testing-enabled NO \
  CODE_SIGNING_ALLOWED=NO
```

Fixes #487
