### PR TITLE
Fix startup crash when plugin directory cannot be observed

### DIFF
--- a/SwiftBar/Plugin/PluginManger.swift
+++ b/SwiftBar/Plugin/PluginManger.swift
@@ -821,10 +821,19 @@ class PluginManager: ObservableObject {
 
     #if !MAC_APP_STORE
         func configureDirectoryObserver() {
-            if let url = pluginDirectoryURL {
-                directoryObserver = DirectoryObserver(url: url, block: { [weak self] in
+            guard let url = pluginDirectoryURL else {
+                directoryObserver = nil
+                return
+            }
+
+            do {
+                directoryObserver = try DirectoryObserver(url: url, block: { [weak self] in
                     self?.directoryChanged()
                 })
+            } catch {
+                directoryObserver = nil
+                os_log("Failed to configure plugin directory observer: %{public}@",
+                       log: Log.plugin, type: .error, error.localizedDescription)
             }
         }
     #endif

--- a/SwiftBar/Utility/DirectoryObserver.swift
+++ b/SwiftBar/Utility/DirectoryObserver.swift
@@ -2,22 +2,36 @@ import Foundation
 
 #if !MAC_APP_STORE
 
-    class DirectoryObserver {
-        private let fileDescriptor: CInt
+    struct DirectoryObserverError: LocalizedError {
+        let url: URL
+        let errorCode: CInt
+
+        var errorDescription: String? {
+            "Failed to open directory \(url.path): \(String(cString: strerror(errorCode))) (\(errorCode))"
+        }
+    }
+
+    final class DirectoryObserver {
         private let source: DispatchSourceProtocol
         public let url: URL
 
         deinit {
-            self.source.cancel()
-            close(fileDescriptor)
+            source.cancel()
         }
 
-        init(url: URL, block: @escaping () -> Void) {
+        init(url: URL, block: @escaping () -> Void) throws {
+            let fileDescriptor = open(url.path, O_EVTONLY)
+            guard fileDescriptor >= 0 else {
+                throw DirectoryObserverError(url: url, errorCode: errno)
+            }
+
             self.url = url
-            fileDescriptor = open(url.path, O_EVTONLY)
             source = DispatchSource.makeFileSystemObjectSource(fileDescriptor: fileDescriptor, eventMask: .all, queue: DispatchQueue.global())
             source.setEventHandler {
                 block()
+            }
+            source.setCancelHandler {
+                close(fileDescriptor)
             }
             source.resume()
         }

--- a/SwiftBarTests/DirectoryObserverTests.swift
+++ b/SwiftBarTests/DirectoryObserverTests.swift
@@ -1,0 +1,41 @@
+#if !MAC_APP_STORE
+    import Foundation
+    import Testing
+
+    @testable import SwiftBar
+
+    struct DirectoryObserverTests {
+        @Test func reportsOpenFailureForMissingDirectory() {
+            let missingDirectory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+
+            do {
+                _ = try DirectoryObserver(url: missingDirectory, block: {})
+                Issue.record("Expected directory observation to fail")
+            } catch let error as DirectoryObserverError {
+                #expect(error.url == missingDirectory)
+                #expect(error.errorCode == ENOENT)
+            } catch {
+                Issue.record("Unexpected error: \(error)")
+            }
+        }
+
+        @Test func observesAccessibleDirectory() throws {
+            let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+            defer { try? FileManager.default.removeItem(at: directory) }
+
+            let observer = try DirectoryObserver(url: directory, block: {})
+
+            #expect(observer.url == directory)
+        }
+
+        @Test func pluginManagerHandlesDirectoryOpenFailure() {
+            let missingDirectory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+            let manager = TestDirectoryPluginManager(pluginDirectoryURL: missingDirectory)
+
+            manager.configureDirectoryObserver()
+
+            #expect(manager.directoryObserver == nil)
+        }
+    }
+#endif


### PR DESCRIPTION
## Summary

- fail cleanly when SwiftBar cannot open the configured plugin directory
- log the path and POSIX error instead of passing an invalid descriptor to Dispatch
- close the watched descriptor through the dispatch source cancellation handler
- add regression coverage for missing and accessible directories and plugin-manager recovery

## Root cause

`open(..., O_EVTONLY)` can return `-1` when the configured plugin directory becomes unavailable. SwiftBar passed that value to `DispatchSource.makeFileSystemObjectSource`, causing a `SIGTRAP` during startup.

This addresses [discussion #498](https://github.com/swiftbar/SwiftBar/discussions/498).

## Validation

- focused `DirectoryObserverTests` suite: 3 tests passed
- complete `SwiftBarTests` target passed