### PR TITLE
fix(plugins): preserve UTF-8 across stream chunks

### DIFF
--- a/SwiftBar/Utility/RunScript.swift
+++ b/SwiftBar/Utility/RunScript.swift
@@ -4,6 +4,56 @@ import os
 
 let sharedEnv = Environment.shared
 
+struct UTF8ChunkDecoder {
+    private var pendingBytes: [UInt8] = []
+
+    mutating func decode(_ data: Data) -> String {
+        pendingBytes.append(contentsOf: data)
+
+        let completeBytesEnd = incompleteSequenceStart() ?? pendingBytes.endIndex
+        let decoded = String(decoding: pendingBytes[..<completeBytesEnd], as: UTF8.self)
+        pendingBytes = Array(pendingBytes[completeBytesEnd...])
+        return decoded
+    }
+
+    mutating func finish() -> String {
+        defer { pendingBytes.removeAll() }
+        return String(decoding: pendingBytes, as: UTF8.self)
+    }
+
+    private func incompleteSequenceStart() -> Int? {
+        guard !pendingBytes.isEmpty else { return nil }
+
+        var sequenceStart = pendingBytes.index(before: pendingBytes.endIndex)
+        while sequenceStart > pendingBytes.startIndex,
+              pendingBytes[sequenceStart] & 0b1100_0000 == 0b1000_0000
+        {
+            sequenceStart = pendingBytes.index(before: sequenceStart)
+        }
+
+        let expectedLength: Int
+        switch pendingBytes[sequenceStart] {
+        case 0b1100_0010 ... 0b1101_1111:
+            expectedLength = 2
+        case 0b1110_0000 ... 0b1110_1111:
+            expectedLength = 3
+        case 0b1111_0000 ... 0b1111_0100:
+            expectedLength = 4
+        default:
+            return nil
+        }
+
+        let actualLength = pendingBytes.distance(from: sequenceStart, to: pendingBytes.endIndex)
+        guard actualLength < expectedLength else { return nil }
+        guard pendingBytes[pendingBytes.index(after: sequenceStart)...]
+            .allSatisfy({ $0 & 0b1100_0000 == 0b1000_0000 })
+        else {
+            return nil
+        }
+        return sequenceStart
+    }
+}
+
 func getEnvExportString(env: [String: String]) -> String {
     let dict = sharedEnv.systemEnvStr.merging(env) { current, _ in current }
     let shell = sharedEnv.userLoginShell.lowercased()
@@ -131,12 +181,16 @@ private extension Process {
         }
 
         let outputQueue = DispatchQueue(label: "bash-output-queue")
+        var outputDecoder = UTF8ChunkDecoder()
 
         outputPipe.fileHandleForReading.readabilityHandler = { handler in
             let data = handler.availableData
             outputQueue.async {
                 outputData.append(data)
-                onOutputUpdate(String(data: data, encoding: .utf8))
+                let decoded = data.isEmpty ? outputDecoder.finish() : outputDecoder.decode(data)
+                if !decoded.isEmpty {
+                    onOutputUpdate(decoded)
+                }
             }
         }
 

--- a/SwiftBarTests/RunScriptTests.swift
+++ b/SwiftBarTests/RunScriptTests.swift
@@ -1,0 +1,106 @@
+import Foundation
+import Testing
+
+@testable import SwiftBar
+
+private final class OutputRecorder {
+    private let lock = NSLock()
+    private var values: [String?] = []
+    private var writeError: String?
+
+    func append(_ value: String?) -> Bool {
+        lock.lock()
+        values.append(value)
+        let isFirstValue = values.count == 1
+        lock.unlock()
+        return isFirstValue
+    }
+
+    func recordWriteError(_ error: Error) {
+        lock.lock()
+        writeError = error.localizedDescription
+        lock.unlock()
+    }
+
+    func recordedValues() -> [String?] {
+        lock.lock()
+        defer { lock.unlock() }
+        return values
+    }
+
+    func recordedWriteError() -> String? {
+        lock.lock()
+        defer { lock.unlock() }
+        return writeError
+    }
+}
+
+struct RunScriptTests {
+    @Test func utf8ChunkDecoder_reassemblesScalarsSplitAtEveryByte() {
+        let expected = "A¢●🌍Z"
+        let bytes = Array(expected.utf8)
+
+        for splitIndex in 0 ... bytes.count {
+            var decoder = UTF8ChunkDecoder()
+            let first = decoder.decode(Data(bytes[..<splitIndex]))
+            let second = decoder.decode(Data(bytes[splitIndex...]))
+
+            #expect(first + second + decoder.finish() == expected)
+        }
+
+        var byteAtATimeDecoder = UTF8ChunkDecoder()
+        let byteAtATime = bytes
+            .map { byteAtATimeDecoder.decode(Data([$0])) }
+            .joined()
+        #expect(byteAtATime + byteAtATimeDecoder.finish() == expected)
+    }
+
+    @Test func utf8ChunkDecoder_replacesIncompleteScalarAtEndOfStream() {
+        var decoder = UTF8ChunkDecoder()
+
+        #expect(decoder.decode(Data([0xE2, 0x97])).isEmpty)
+        #expect(decoder.finish() == "�")
+        #expect(decoder.finish().isEmpty)
+    }
+
+    @Test func runScript_streamOutputPreservesUTF8SplitAcrossPipeReads() throws {
+        let tempDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDirectory) }
+
+        let scriptURL = tempDirectory.appendingPathComponent("split-utf8.sh")
+        let script = """
+        #!/bin/sh
+        printf 'prefix \\342\\227'
+        read _
+        printf '\\217 suffix\\n'
+        """
+        try Data(script.utf8).write(to: scriptURL)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: scriptURL.path)
+
+        let recorder = OutputRecorder()
+        let stdinPipe = Pipe()
+        let result = try runScript(
+            to: scriptURL.path,
+            runInBash: false,
+            streamOutput: true,
+            stdinPipe: stdinPipe,
+            onOutputUpdate: { value in
+                if recorder.append(value) {
+                    do {
+                        try stdinPipe.fileHandleForWriting.write(contentsOf: Data("\n".utf8))
+                    } catch {
+                        recorder.recordWriteError(error)
+                    }
+                }
+            }
+        )
+        let updates = recorder.recordedValues()
+
+        #expect(recorder.recordedWriteError() == nil)
+        #expect(updates.allSatisfy { $0 != nil })
+        #expect(updates.compactMap { $0 }.joined() == "prefix ● suffix\n")
+        #expect(result.out == "prefix ● suffix\n")
+    }
+}


### PR DESCRIPTION
## Summary

- retain incomplete UTF-8 sequences between streaming stdout pipe reads
- decode malformed or incomplete trailing bytes without sending a `nil` content update
- cover every scalar byte boundary and a synchronized two-write pipe reproduction

## Root cause

`RunScript` decoded each `FileHandle.availableData` chunk independently. Pipe reads can split a multi-byte UTF-8 scalar, causing `String(data:encoding:)` to return `nil`. `StreamablePlugin` treated that update as empty content and hid the menu bar item.

## Validation

- `xcodebuild test -project SwiftBar.xcodeproj -scheme SwiftBar -destination 'platform=macOS,arch=arm64' -only-testing:SwiftBarTests/RunScriptTests CODE_SIGNING_ALLOWED=NO`
- `xcodebuild test -project SwiftBar.xcodeproj -scheme SwiftBar -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO`
- mutation check: restoring the original per-chunk decode makes the synchronized pipe regression test fail

Fixes #497