### PR TITLE
fix(menu): update paired images on appearance changes

### DIFF
--- a/SwiftBar/AppShared.swift
+++ b/SwiftBar/AppShared.swift
@@ -272,11 +272,8 @@ class AppShared: NSObject {
         UserDefaults.standard.string(forKey: "AppleInterfaceStyle") != nil
     }
 
-    public static var isDarkStatusBar: Bool {
-        let item = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
-        let currentAppearance = item.button?.effectiveAppearance
-        NSStatusBar.system.removeStatusItem(item)
-        return currentAppearance?.bestMatch(from: [.aqua, .darkAqua]) == .aqua
+    public static func isDarkStatusBar(appearance: NSAppearance?) -> Bool {
+        appearance?.bestMatch(from: [.aqua, .darkAqua]) == .aqua
     }
 
     public static var isReduceTransparencyEnabled: Bool {

--- a/SwiftBar/MenuBar/MenuBarItem.swift
+++ b/SwiftBar/MenuBar/MenuBarItem.swift
@@ -1324,7 +1324,7 @@ extension MenubarItem {
         }
 
         let params = MenuLineParameters(line: displayText)
-        if let image = params.getImage(isMenuBarItem: true) {
+        if let image = params.getImage(isMenuBarItem: true, menuBarAppearance: barItem.button?.effectiveAppearance) {
             barItem.button?.image = image
             barItem.button?.imagePosition = .imageLeft
         }

--- a/SwiftBar/MenuBar/MenuLineParameters.swift
+++ b/SwiftBar/MenuBar/MenuLineParameters.swift
@@ -317,7 +317,7 @@ struct MenuLineParameters: Codable, Equatable {
         return sfmc
     }
 
-    func getImage(isMenuBarItem: Bool = false) -> NSImage? {
+    func getImage(isMenuBarItem: Bool = false, menuBarAppearance: NSAppearance? = nil) -> NSImage? {
         if #available(OSX 11.0, *) {
             if let sfString = params["sfimage"] {
                 // Handle comma-separated SF symbols for light/dark themes
@@ -326,7 +326,7 @@ struct MenuLineParameters: Codable, Equatable {
                 let darkSymbol = sfSymbols.count > 1 ? sfSymbols.last?.trimmingCharacters(in: .whitespaces) : lightSymbol
 
                 // Choose symbol based on theme context
-                let shouldUseDarkSymbol = isMenuBarItem ? AppShared.isDarkStatusBar : AppShared.isDarkTheme
+                let shouldUseDarkSymbol = isMenuBarItem ? AppShared.isDarkStatusBar(appearance: menuBarAppearance) : AppShared.isDarkTheme
                 let symbolToUse = (shouldUseDarkSymbol && darkSymbol != lightSymbol) ? darkSymbol : lightSymbol
 
                 guard let finalSymbol = symbolToUse else { return nil }
@@ -366,7 +366,7 @@ struct MenuLineParameters: Codable, Equatable {
             let darkImage = images?.last
 
             // Use isDarkStatusBar for menu bar items, isDarkTheme for dropdown items
-            let shouldUseDarkImage = isMenuBarItem ? AppShared.isDarkStatusBar : AppShared.isDarkTheme
+            let shouldUseDarkImage = isMenuBarItem ? AppShared.isDarkStatusBar(appearance: menuBarAppearance) : AppShared.isDarkTheme
             return resizedImageIfRequested(NSImage.createImage(from: shouldUseDarkImage || darkImage == nil ? lightImage : darkImage, isTemplate: false))
         }
 

--- a/SwiftBarTests/SwiftBarTests.swift
+++ b/SwiftBarTests/SwiftBarTests.swift
@@ -2318,6 +2318,42 @@ struct MenuDiffTests {
     }
 }
 
+// MARK: - Menu Bar Image Appearance Tests
+
+struct MenuBarImageAppearanceTests {
+    @MainActor
+    private func makeBase64PNG(color: NSColor) throws -> String {
+        let size = NSSize(width: 2, height: 2)
+        let image = NSImage(size: size)
+        image.lockFocus()
+        color.setFill()
+        NSBezierPath(rect: NSRect(origin: .zero, size: size)).fill()
+        image.unlockFocus()
+
+        let tiffData = try #require(image.tiffRepresentation)
+        let bitmapRep = try #require(NSBitmapImageRep(data: tiffData))
+        let pngData = try #require(bitmapRep.representation(using: .png, properties: [:]))
+        return pngData.base64EncodedString()
+    }
+
+    @MainActor @Test func testMenuBarPairedImageFollowsStatusButtonAppearance() throws {
+        let aquaImage = try makeBase64PNG(color: .systemRed)
+        let darkAquaImage = try makeBase64PNG(color: .systemBlue)
+        let item = MenubarItem(title: "Test")
+        let title = "Test | image=\(aquaImage),\(darkAquaImage)"
+
+        item.barItem.button?.appearance = NSAppearance(named: .aqua)
+        item.setMenuTitle(title: title)
+        let aquaRepresentation = try #require(item.barItem.button?.image?.tiffRepresentation)
+
+        item.barItem.button?.appearance = NSAppearance(named: .darkAqua)
+        item.setMenuTitle(title: title)
+        let darkAquaRepresentation = try #require(item.barItem.button?.image?.tiffRepresentation)
+
+        #expect(aquaRepresentation != darkAquaRepresentation)
+    }
+}
+
 // MARK: - Fold Parameter Tests
 
 struct FoldParameterTests {


### PR DESCRIPTION
## Summary

- select paired menu-bar images and SF Symbols from the existing status button's effective appearance
- remove the temporary `NSStatusItem` appearance probe
- cover Aqua-to-Dark-Aqua image changes through `MenubarItem.setMenuTitle`

## Root cause

`AppShared.isDarkStatusBar` created a temporary status item and read its appearance before AppKit attached it to the live menu bar. On macOS 27.0, that button reported Aqua in both Light and Dark appearances, so `image=light_b64,dark_b64` kept selecting the same image. The dropdown path used the global appearance and changed correctly.

The fix passes `barItem.button?.effectiveAppearance` into the existing image-selection path. This keeps menu-bar material-aware selection and avoids the temporary AppKit scene.

## Test

- `xcodebuild -project SwiftBar.xcodeproj -scheme SwiftBar -configuration Debug -destination 'platform=macOS,arch=arm64' -derivedDataPath /tmp/swiftbar-486-fix-derived test -only-testing:SwiftBarTests/MenuBarImageAppearanceTests`
- `xcodebuild -quiet -project SwiftBar.xcodeproj -scheme SwiftBar -configuration Debug -destination 'platform=macOS,arch=arm64' -derivedDataPath /tmp/swiftbar-486-fix-derived test`

Verified on macOS 27.0 (26A5378j) with Xcode 27.0 (27A5194q). This host cannot run macOS 26 Tahoe, so the fix was not exercised on Tahoe directly.

Fixes #486
