### PR TITLE
Fix base64 menu item images on macOS 26

### DIFF
--- a/SwiftBar/MenuBar/MenuBarItem.swift
+++ b/SwiftBar/MenuBar/MenuBarItem.swift
@@ -984,7 +984,7 @@ extension MenubarItem {
         item.representedObject = params
 
         let title = atributedTitle(with: params)
-        item.attributedTitle = menuTitle(title.title, image: params.image)
+        configureMenuImage(on: item, title: title.title, params: params)
 
         item.toolTip = params.tooltip?.replacingOccurrences(of: "\\n", with: "\n")
         if let length = params.length, length < title.title.string.count {
@@ -993,11 +993,6 @@ extension MenubarItem {
 
         item.isAlternate = params.alternate
 
-        if #available(macOS 26.0, *), params.image != nil {
-            item.image = nil
-        } else {
-            item.image = params.image
-        }
         item.state = params.checked ? .on : .off
 
         if #available(macOS 14.0, *) {
@@ -1018,13 +1013,58 @@ extension MenubarItem {
         return (normalTitle, highlightedTitle)
     }
 
-    private func menuTitle(_ title: NSAttributedString, image: NSImage?) -> NSAttributedString {
-        guard #available(macOS 26.0, *), let image else { return title }
+    enum MenuImagePresentation {
+        case native
+        case attributed
+    }
 
-        let icon = image.resizedCopy(w: 16, h: 16).tintedImage(color: .labelColor)
+    func configureMenuImage(
+        on item: NSMenuItem,
+        title: NSAttributedString,
+        params: MenuLineParameters,
+        presentation: MenuImagePresentation? = nil
+    ) {
+        let resolvedPresentation: MenuImagePresentation = if let presentation {
+            presentation
+        } else if #available(macOS 26.0, *) {
+            .attributed
+        } else {
+            .native
+        }
+
+        let image = params.image
+        switch resolvedPresentation {
+        case .native:
+            item.attributedTitle = title
+            item.image = image
+        case .attributed:
+            item.attributedTitle = menuTitle(
+                title,
+                image: image,
+                usesExplicitSize: params.params["width"].flatMap(Double.init) != nil
+                    && params.params["height"].flatMap(Double.init) != nil
+            )
+            item.image = nil
+        }
+    }
+
+    private func menuTitle(
+        _ title: NSAttributedString,
+        image: NSImage?,
+        usesExplicitSize: Bool
+    ) -> NSAttributedString {
+        guard let image else { return title }
+
+        let icon: NSImage
+        if !usesExplicitSize, image.size.width > 16 || image.size.height > 16 {
+            let scale = min(16 / image.size.width, 16 / image.size.height)
+            icon = image.resizedCopy(w: image.size.width * scale, h: image.size.height * scale)
+        } else {
+            icon = image
+        }
         let font = title.length > 0 ? title.attribute(.font, at: 0, effectiveRange: nil) as? NSFont : nil
         let menuFont = font ?? .menuFont(ofSize: 0)
-        let result = NSMutableAttributedString(attachment: .centeredImage(with: icon, and: menuFont))
+        let result = NSMutableAttributedString(attachment: .centeredMenuImage(with: icon, and: menuFont))
         result.append(NSAttributedString(string: "  "))
         result.append(title)
         return result
@@ -1488,7 +1528,7 @@ extension MenubarItem {
                               keyEquivalent: "")
         item.representedObject = params
         let title = atributedTitle(with: params)
-        item.attributedTitle = menuTitle(title.title, image: params.image)
+        configureMenuImage(on: item, title: title.title, params: params)
 
         item.toolTip = params.tooltip?.replacingOccurrences(of: "\\n", with: "\n")
 
@@ -1499,10 +1539,6 @@ extension MenubarItem {
         if params.alternate {
             item.isAlternate = true
             item.keyEquivalentModifierMask = NSEvent.ModifierFlags.option
-        }
-
-        if #unavailable(macOS 26.0), let image = params.image {
-            item.image = image
         }
 
         if params.checked {

--- a/SwiftBar/MenuBar/MenuBarItem.swift
+++ b/SwiftBar/MenuBar/MenuBarItem.swift
@@ -984,7 +984,7 @@ extension MenubarItem {
         item.representedObject = params
 
         let title = atributedTitle(with: params)
-        item.attributedTitle = title.title
+        item.attributedTitle = menuTitle(title.title, image: params.image)
 
         item.toolTip = params.tooltip?.replacingOccurrences(of: "\\n", with: "\n")
         if let length = params.length, length < title.title.string.count {
@@ -993,7 +993,11 @@ extension MenubarItem {
 
         item.isAlternate = params.alternate
 
-        item.image = params.image
+        if #available(macOS 26.0, *), params.image != nil {
+            item.image = nil
+        } else {
+            item.image = params.image
+        }
         item.state = params.checked ? .on : .off
 
         if #available(macOS 14.0, *) {
@@ -1012,6 +1016,18 @@ extension MenubarItem {
             range: NSRange(location: 0, length: highlightedTitle.length)
         )
         return (normalTitle, highlightedTitle)
+    }
+
+    private func menuTitle(_ title: NSAttributedString, image: NSImage?) -> NSAttributedString {
+        guard #available(macOS 26.0, *), let image else { return title }
+
+        let icon = image.resizedCopy(w: 16, h: 16).tintedImage(color: .labelColor)
+        let font = title.length > 0 ? title.attribute(.font, at: 0, effectiveRange: nil) as? NSFont : nil
+        let menuFont = font ?? .menuFont(ofSize: 0)
+        let result = NSMutableAttributedString(attachment: .centeredImage(with: icon, and: menuFont))
+        result.append(NSAttributedString(string: "  "))
+        result.append(title)
+        return result
     }
 
     private func syncHotKeys() {
@@ -1472,7 +1488,7 @@ extension MenubarItem {
                               keyEquivalent: "")
         item.representedObject = params
         let title = atributedTitle(with: params)
-        item.attributedTitle = title.title
+        item.attributedTitle = menuTitle(title.title, image: params.image)
 
         item.toolTip = params.tooltip?.replacingOccurrences(of: "\\n", with: "\n")
 
@@ -1485,7 +1501,7 @@ extension MenubarItem {
             item.keyEquivalentModifierMask = NSEvent.ModifierFlags.option
         }
 
-        if let image = params.image {
+        if #unavailable(macOS 26.0), let image = params.image {
             item.image = image
         }
 

--- a/SwiftBar/Utility/NSMutableAttributedString+SFSymbols.swift
+++ b/SwiftBar/Utility/NSMutableAttributedString+SFSymbols.swift
@@ -58,6 +58,13 @@ extension NSTextAttachment {
         imageAttachment.attachmentCell = ImageAttachmentCell(imageCell: image)
         return imageAttachment
     }
+
+    static func centeredMenuImage(with image: NSImage, and font: NSFont) -> NSTextAttachment {
+        let imageAttachment = NSTextAttachment()
+        imageAttachment.bounds = CGRect(x: 0, y: (font.capHeight - image.size.height).rounded() / 2, width: image.size.width, height: image.size.height)
+        imageAttachment.attachmentCell = MenuImageAttachmentCell(imageCell: image)
+        return imageAttachment
+    }
 }
 
 class ImageAttachmentCell: NSTextAttachmentCell {
@@ -65,5 +72,21 @@ class ImageAttachmentCell: NSTextAttachmentCell {
         var baseline = super.cellBaselineOffset()
         baseline.y = baseline.y - 3 - (image!.size.height - 16) / 2
         return baseline
+    }
+}
+
+final class MenuImageAttachmentCell: ImageAttachmentCell {
+    override func draw(withFrame cellFrame: NSRect, in controlView: NSView?) {
+        guard let image else { return }
+
+        let drawImage = {
+            let color: NSColor = self.isHighlighted ? .selectedMenuItemTextColor : .labelColor
+            image.tintedImage(color: color).draw(in: cellFrame)
+        }
+        if let appearance = controlView?.effectiveAppearance {
+            appearance.performAsCurrentDrawingAppearance(drawImage)
+        } else {
+            drawImage()
+        }
     }
 }

--- a/SwiftBarTests/SwiftBarTests.swift
+++ b/SwiftBarTests/SwiftBarTests.swift
@@ -2507,6 +2507,29 @@ struct FoldMenuItemBuildTests {
         return pngData.base64EncodedString()
     }
 
+    @MainActor @Test func testFullBuild_embedsImageInTitleOnTahoe() throws {
+        let item = makeMenuBarItem()
+        let image = try makeBase64PNG(size: NSSize(width: 54, height: 54))
+
+        item._updateMenu(content: """
+        Title
+        ---
+        Image | templateImage=\(image)
+        """)
+
+        let imageItem = try #require(menuItem(named: "Image", in: item.statusBarMenu))
+        if #available(macOS 26.0, *) {
+            #expect(imageItem.image == nil)
+            let title = try #require(imageItem.attributedTitle)
+            #expect(title.string.hasSuffix("Image"))
+            #expect(title.attribute(.attachment, at: 0, effectiveRange: nil) is NSTextAttachment)
+        } else {
+            let menuImage = try #require(imageItem.image)
+            #expect(menuImage.size == NSSize(width: 54, height: 54))
+            #expect(menuImage.isTemplate)
+        }
+    }
+
     @MainActor @Test func testFullBuild_foldItemStartsCollapsed() throws {
         let item = makeMenuBarItem()
 

--- a/SwiftBarTests/SwiftBarTests.swift
+++ b/SwiftBarTests/SwiftBarTests.swift
@@ -2494,10 +2494,10 @@ struct FoldMenuItemBuildTests {
     }
 
     @MainActor
-    private func makeBase64PNG(size: NSSize) throws -> String {
+    private func makeBase64PNG(size: NSSize, color: NSColor = .systemBlue) throws -> String {
         let image = NSImage(size: size)
         image.lockFocus()
-        NSColor.systemBlue.setFill()
+        color.setFill()
         NSBezierPath(rect: NSRect(origin: .zero, size: size)).fill()
         image.unlockFocus()
 
@@ -2507,9 +2507,42 @@ struct FoldMenuItemBuildTests {
         return pngData.base64EncodedString()
     }
 
-    @MainActor @Test func testFullBuild_embedsImageInTitleOnTahoe() throws {
+    @MainActor
+    private func attachmentCell(from item: NSMenuItem) throws -> NSTextAttachmentCell {
+        let title = try #require(item.attributedTitle)
+        let attachment = try #require(title.attribute(.attachment, at: 0, effectiveRange: nil) as? NSTextAttachment)
+        return try #require(attachment.attachmentCell as? NSTextAttachmentCell)
+    }
+
+    @MainActor
+    private func attachedImage(from item: NSMenuItem) throws -> NSImage {
+        try #require(attachmentCell(from: item).image)
+    }
+
+    @MainActor
+    private func renderedAttachment(
+        from item: NSMenuItem,
+        appearance: NSAppearance.Name,
+        highlighted: Bool
+    ) throws -> Data {
+        let cell = try attachmentCell(from: item)
+        let canvas = NSImage(size: NSSize(width: 20, height: 20))
+        let view = NSView(frame: NSRect(origin: .zero, size: canvas.size))
+        view.appearance = NSAppearance(named: appearance)
+
+        canvas.lockFocus()
+        NSColor.clear.setFill()
+        NSRect(origin: .zero, size: canvas.size).fill()
+        cell.isHighlighted = highlighted
+        cell.draw(withFrame: NSRect(x: 2, y: 2, width: 16, height: 16), in: view)
+        canvas.unlockFocus()
+
+        return try #require(canvas.tiffRepresentation)
+    }
+
+    @MainActor @Test func testFullBuild_embedsTemplateImageWithPreservedAspectRatioOnMacOS26AndLater() throws {
         let item = makeMenuBarItem()
-        let image = try makeBase64PNG(size: NSSize(width: 54, height: 54))
+        let image = try makeBase64PNG(size: NSSize(width: 54, height: 27))
 
         item._updateMenu(content: """
         Title
@@ -2520,14 +2553,119 @@ struct FoldMenuItemBuildTests {
         let imageItem = try #require(menuItem(named: "Image", in: item.statusBarMenu))
         if #available(macOS 26.0, *) {
             #expect(imageItem.image == nil)
-            let title = try #require(imageItem.attributedTitle)
-            #expect(title.string.hasSuffix("Image"))
-            #expect(title.attribute(.attachment, at: 0, effectiveRange: nil) is NSTextAttachment)
+            #expect(imageItem.attributedTitle?.string.hasSuffix("Image") == true)
+            let attachedImage = try attachedImage(from: imageItem)
+            #expect(attachedImage.size == NSSize(width: 16, height: 8))
+            #expect(attachedImage.isTemplate)
         } else {
             let menuImage = try #require(imageItem.image)
-            #expect(menuImage.size == NSSize(width: 54, height: 54))
+            #expect(menuImage.size == NSSize(width: 54, height: 27))
             #expect(menuImage.isTemplate)
         }
+    }
+
+    @MainActor @Test func testFullBuild_preservesRequestedSizeForColorImageOnMacOS26AndLater() throws {
+        let item = makeMenuBarItem()
+        let image = try makeBase64PNG(size: NSSize(width: 40, height: 20), color: .systemRed)
+
+        item._updateMenu(content: """
+        Title
+        ---
+        Image | image=\(image) width=30 height=12
+        """)
+
+        let imageItem = try #require(menuItem(named: "Image", in: item.statusBarMenu))
+        if #available(macOS 26.0, *) {
+            #expect(imageItem.image == nil)
+            let attachedImage = try attachedImage(from: imageItem)
+            #expect(attachedImage.size == NSSize(width: 30, height: 12))
+            #expect(!attachedImage.isTemplate)
+        } else {
+            let menuImage = try #require(imageItem.image)
+            #expect(menuImage.size == NSSize(width: 30, height: 12))
+            #expect(!menuImage.isTemplate)
+        }
+    }
+
+    @MainActor @Test func testIncrementalRefresh_replacesAttributedColorImageInPlaceOnMacOS26AndLater() throws {
+        let item = makeMenuBarItem()
+        let redImage = try makeBase64PNG(size: NSSize(width: 32, height: 16), color: .systemRed)
+        let blueImage = try makeBase64PNG(size: NSSize(width: 24, height: 12), color: .systemBlue)
+
+        item._updateMenu(content: """
+        Title
+        ---
+        Image | image=\(redImage)
+        """)
+        let originalItem = try #require(menuItem(named: "Image", in: item.statusBarMenu))
+        let originalRepresentation = if #available(macOS 26.0, *) {
+            try #require(try attachedImage(from: originalItem).tiffRepresentation)
+        } else {
+            try #require(originalItem.image?.tiffRepresentation)
+        }
+
+        item._updateMenu(content: """
+        Title
+        ---
+        Image | image=\(blueImage)
+        """)
+
+        let refreshedItem = try #require(menuItem(named: "Image", in: item.statusBarMenu))
+        #expect(refreshedItem === originalItem)
+        let refreshedImage: NSImage
+        if #available(macOS 26.0, *) {
+            #expect(refreshedItem.image == nil)
+            refreshedImage = try attachedImage(from: refreshedItem)
+            #expect(refreshedImage.size == NSSize(width: 16, height: 8))
+        } else {
+            refreshedImage = try #require(refreshedItem.image)
+            #expect(refreshedImage.size == NSSize(width: 24, height: 12))
+        }
+        #expect(!refreshedImage.isTemplate)
+        #expect(try #require(refreshedImage.tiffRepresentation) != originalRepresentation)
+    }
+
+    @MainActor @Test func testAttributedTemplateImageSupportsAppearanceAndHighlightTint() throws {
+        let item = makeMenuBarItem()
+        let image = try makeBase64PNG(size: NSSize(width: 16, height: 16))
+        let params = MenuLineParameters(line: "Image | templateImage=\(image)")
+        let menuItem = NSMenuItem()
+
+        item.configureMenuImage(
+            on: menuItem,
+            title: NSAttributedString(string: "Image"),
+            params: params,
+            presentation: .attributed
+        )
+
+        let templateImage = try attachedImage(from: menuItem)
+        #expect(templateImage.isTemplate)
+        let aqua = try renderedAttachment(from: menuItem, appearance: .aqua, highlighted: false)
+        let darkAqua = try renderedAttachment(from: menuItem, appearance: .darkAqua, highlighted: false)
+        let highlighted = try renderedAttachment(from: menuItem, appearance: .aqua, highlighted: true)
+
+        #expect(aqua != darkAqua)
+        #expect(aqua != highlighted)
+    }
+
+    @MainActor @Test func testLegacyPresentation_usesNativeMenuImageWithoutAttachment() throws {
+        let item = makeMenuBarItem()
+        let image = try makeBase64PNG(size: NSSize(width: 21, height: 9))
+        let params = MenuLineParameters(line: "Image | templateImage=\(image)")
+        let menuItem = NSMenuItem()
+
+        item.configureMenuImage(
+            on: menuItem,
+            title: NSAttributedString(string: "Image"),
+            params: params,
+            presentation: .native
+        )
+
+        #expect(menuItem.attributedTitle?.string == "Image")
+        #expect(menuItem.attributedTitle?.attribute(.attachment, at: 0, effectiveRange: nil) == nil)
+        let nativeImage = try #require(menuItem.image)
+        #expect(nativeImage.size == NSSize(width: 21, height: 9))
+        #expect(nativeImage.isTemplate)
     }
 
     @MainActor @Test func testFullBuild_foldItemStartsCollapsed() throws {


### PR DESCRIPTION
Fixes #507.

## Summary

- Render menu item images as inline title attachments on macOS 26 and later, where `NSMenuItem.image` is not displayed.
- Tint template images using the menu label color.
- Preserve the existing native image behavior on earlier macOS versions.
- Add regression coverage for base64 template images.

## Testing

- Ran the complete SwiftBar test suite successfully.
- Reproduced the issue using the script attached to #507 on macOS 27.
- Verified that the Dark Mode icon is now visible beside its label.