### PR TITLE
fix(plugins): recognize packages by path extension

### DIFF
--- a/SwiftBar/Plugin/PluginManger.swift
+++ b/SwiftBar/Plugin/PluginManger.swift
@@ -8,7 +8,7 @@ import UserNotifications
 extension URL {
     /// Whether this URL represents a SwiftBar packaged plugin directory (`.swiftbar` bundle).
     var isSwiftBarPackage: Bool {
-        lastPathComponent.hasSuffix(".swiftbar")
+        pathExtension == "swiftbar"
     }
 }
 

--- a/SwiftBarTests/SwiftBarTests.swift
+++ b/SwiftBarTests/SwiftBarTests.swift
@@ -101,6 +101,16 @@ final class TestDirectoryPluginManager: PluginManager {
 }
 
 struct SwiftBarTests {
+    @Test func testSwiftBarPackageDetection_usesPathExtension() {
+        let barePluginRoot = URL(fileURLWithPath: "/tmp/.swiftbar", isDirectory: true)
+        let package = URL(fileURLWithPath: "/tmp/weather.swiftbar", isDirectory: true)
+        let hiddenPackage = URL(fileURLWithPath: "/tmp/.weather.swiftbar", isDirectory: true)
+
+        #expect(!barePluginRoot.isSwiftBarPackage)
+        #expect(package.isSwiftBarPackage)
+        #expect(hiddenPackage.isSwiftBarPackage)
+    }
+
     @Test func testShouldShowDefaultBarItem_whenNoVisiblePluginsAndNotInStealthMode() async throws {
         #expect(shouldShowDefaultBarItem(hasVisiblePlugins: false, stealthMode: false))
     }
@@ -988,6 +998,37 @@ struct SwiftBarIntegrationTests {
         #expect(plugins.count == 1)
         #expect(plugins.first?.lastPathComponent == packageAliasURL.lastPathComponent)
         #expect(plugins.first?.isSwiftBarPackage == true)
+    }
+
+    @Test func testGetLoadablePluginList_loadsFilesFromBareSwiftBarRoot() throws {
+        let tempDirectory = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDirectory) }
+
+        let pluginRoot = tempDirectory.appendingPathComponent(".swiftbar", isDirectory: true)
+        try FileManager.default.createDirectory(at: pluginRoot, withIntermediateDirectories: true)
+
+        let scriptURL = pluginRoot.appendingPathComponent("script.1m.sh")
+        try Data("#!/bin/zsh\necho script\n".utf8).write(to: scriptURL)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: scriptURL.path)
+
+        let binaryURL = pluginRoot.appendingPathComponent("native-binary")
+        try FileManager.default.copyItem(at: URL(fileURLWithPath: "/usr/bin/true"), to: binaryURL)
+
+        let symlinkTargetURL = tempDirectory.appendingPathComponent("symlink-target.py")
+        try Data("#!/usr/bin/env python3\nprint('symlink')\n".utf8).write(to: symlinkTargetURL)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: symlinkTargetURL.path)
+        let symlinkURL = pluginRoot.appendingPathComponent("symlink.py")
+        try FileManager.default.createSymbolicLink(atPath: symlinkURL.path, withDestinationPath: symlinkTargetURL.path)
+
+        let manager = TestDirectoryPluginManager(pluginDirectoryURL: pluginRoot)
+        let candidates = manager.getPluginList()
+        let loadablePlugins = manager.getLoadablePluginList(from: candidates)
+        let expectedNames: Set<String> = ["native-binary", "script.1m.sh", "symlink.py"]
+
+        #expect(Set(candidates.map(\.lastPathComponent)) == expectedNames)
+        #expect(Set(loadablePlugins.map(\.lastPathComponent)) == expectedNames)
+        #expect(loadablePlugins.allSatisfy { pluginFileState(for: $0) != nil })
     }
 
     @Test func testMergePluginsPreservingOrder_replacesModifiedPluginsInPlace() async throws {


### PR DESCRIPTION
## Root cause

Packaged-plugin detection used `lastPathComponent.hasSuffix(".swiftbar")`. That also classified the conventional bare plugin root `~/.swiftbar` as a package, so files beneath it were routed through packaged-plugin entry-point validation and rejected as “not a regular file.”

## Fix

Use `URL.pathExtension` to recognize packaged plugins. The bare `.swiftbar` root has no path extension, while genuine packages such as `weather.swiftbar` and `.weather.swiftbar` retain the `swiftbar` extension.

Add regression coverage for:

- the bare `.swiftbar` root
- regular and hidden packaged-plugin names
- a script, native executable, and symlink loaded from the conventional root

## Validation

- Focused package/root tests: 2 passed
- Full `xcodebuild test -project SwiftBar.xcodeproj -scheme SwiftBar -destination 'platform=macOS'`: 183 passed, 0 failed, 0 skipped
- Isolated post-fix app reproduction:
  - hidden `.swiftbar`: 4/4 plugins loaded and succeeded
  - visible `swiftbar`: 4/4 plugins loaded and succeeded
  - fixtures included a Python script, compiled Mach-O executable, symlink, and `weather.swiftbar` package

## Limitations

The post-fix runtime reproduction ran on macOS 27.0 build 26A5378j. The reporter's macOS 26.5.2 environment was not available, but the regression is a platform-independent lexical path check and was reproduced in released 2.1.0 before this change.

Closes #508