### PR TITLE
chore(release): prepare 2.1.2 beta 1

### DIFF
--- a/SwiftBar.xcodeproj/project.pbxproj
+++ b/SwiftBar.xcodeproj/project.pbxproj
@@ -871,7 +871,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 597;
+				CURRENT_PROJECT_VERSION = 600;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"SwiftBar/Preview Content\"";
 				DEVELOPMENT_TEAM = X93LWC49WV;
@@ -884,7 +884,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 2.1.1;
+				MARKETING_VERSION = 2.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ameba.SwiftBar;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -900,7 +900,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 597;
+				CURRENT_PROJECT_VERSION = 600;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"SwiftBar/Preview Content\"";
 				DEVELOPMENT_TEAM = X93LWC49WV;
@@ -913,7 +913,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 2.1.1;
+				MARKETING_VERSION = 2.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ameba.SwiftBar;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;


### PR DESCRIPTION
## Summary

- prepare the SwiftBar 2.1.2 beta 1 patch release
- set `MARKETING_VERSION` to `2.1.2` and `CURRENT_PROJECT_VERSION` to build 600
- validate the complete test suite and signed universal Release archive

Build 600 matches the revision count after this release-preparation commit.

## Release notes

### SwiftBar 2.1.2 beta 1

This beta fixes two menu regressions and is intended for validation before the stable 2.1.2 release.

- Restored the intrinsic size of Base64 and template images in dropdown menu items on macOS 26 and later. [#513](https://github.com/swiftbar/SwiftBar/issues/513) [#516](https://github.com/swiftbar/SwiftBar/pull/516)
- Fixed submenu parents becoming disabled after incremental child or title changes. [#512](https://github.com/swiftbar/SwiftBar/issues/512) [#514](https://github.com/swiftbar/SwiftBar/issues/514) [#515](https://github.com/swiftbar/SwiftBar/issues/515) [#518](https://github.com/swiftbar/SwiftBar/pull/518)

Please test the affected image and submenu-refresh scenarios and report any remaining regressions before the stable release.

**Full changelog:** https://github.com/swiftbar/SwiftBar/compare/v2.1.1...v2.1.2-beta-1

## Validation

Full suite:

```sh
DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer \
xcodebuild test -quiet -project SwiftBar.xcodeproj -scheme SwiftBar \
  -configuration Debug -destination "platform=macOS,arch=arm64" \
  -derivedDataPath /tmp/swiftbar-2.1.2-beta-1-release-prep/TestDerivedData \
  -resultBundlePath /tmp/swiftbar-2.1.2-beta-1-release-prep/SwiftBarTests.xcresult \
  -parallel-testing-enabled NO CODE_SIGNING_ALLOWED=NO
```

Result: 198 passed, 0 failed, 0 skipped.

Release archive:

```sh
DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer \
xcodebuild archive -quiet -project SwiftBar.xcodeproj -scheme SwiftBar \
  -configuration Release -destination "generic/platform=macOS" \
  -derivedDataPath /tmp/swiftbar-2.1.2-beta-1-release-prep/ArchiveDerivedData \
  -archivePath /tmp/swiftbar-2.1.2-beta-1-release-prep/SwiftBar.xcarchive \
  CODE_SIGN_STYLE=Manual \
  CODE_SIGN_IDENTITY="Developer ID Application: Ameba Labs, LLC (X93LWC49WV)" \
  DEVELOPMENT_TEAM=X93LWC49WV
```

The archive was verified with `codesign --verify --deep --strict`:

- version: `2.1.2 (600)`
- architectures: `arm64`, `x86_64`
- minimum macOS: `12.0`
- hardened runtime: enabled
- signing team: `X93LWC49WV`

The archive is intentionally not notarized at this stage. Gatekeeper reports `source=Unnotarized Developer ID`; notarization and stapling happen after this PR merges. The validation host uses Xcode 27 beta, which was approved for release preparation.

## Publication

This PR does not create a tag or GitHub release. After merge, build and notarize `SwiftBar.v2.1.2.b600.zip`, verify the artifact, create the signed `v2.1.2-beta-1` tag, and prepare the prerelease for final approval.
