### PR TITLE
fix(plugins): restore support directory compatibility

### DIFF
--- a/SwiftBar/Plugin/ExecutablePlugin.swift
+++ b/SwiftBar/Plugin/ExecutablePlugin.swift
@@ -55,7 +55,7 @@ class ExecutablePlugin: TimerArmingPlugin {
 
     let prefs = PreferencesStore.shared
 
-    init(fileURL: URL) {
+    init(fileURL: URL, createSupportDirectories: Bool = true) {
         let nameComponents = fileURL.lastPathComponent.components(separatedBy: ".")
         // Use resolved path as ID to ensure uniqueness even with symlinks
         id = fileURL.resolvingSymlinksInPath().path
@@ -69,7 +69,9 @@ class ExecutablePlugin: TimerArmingPlugin {
         if metadata?.nextDate == nil, nameComponents.count > 2 {
             updateInterval = nameComponents.dropFirst().compactMap { parseRefreshInterval(intervalStr: $0, baseUpdateinterval: updateInterval) }.reduce(updateInterval, min)
         }
-        createSupportDirs()
+        if createSupportDirectories {
+            createSupportDirs()
+        }
         os_log("Initialized executable plugin\n%{public}@", log: Log.plugin, description)
         refresh(reason: .FirstLaunch)
     }

--- a/SwiftBar/Plugin/PackagedPlugin.swift
+++ b/SwiftBar/Plugin/PackagedPlugin.swift
@@ -11,6 +11,10 @@ class PackagedPlugin: TimerArmingPlugin {
     var file: String
     let packageDirectory: URL
     let mainExecutable: URL
+    var supportDirectoryName: String {
+        packageDirectory.lastPathComponent
+    }
+
     var updateInterval: Double = pluginNeverUpdateInterval
     var refreshEnv: [String: String] = [:]
 
@@ -61,7 +65,7 @@ class PackagedPlugin: TimerArmingPlugin {
     // MARK: - Initialization
 
     /// Initialize with a `.swiftbar` directory URL.
-    init?(packageDirectory: URL) {
+    init?(packageDirectory: URL, createSupportDirectories: Bool = true) {
         guard packageDirectory.isSwiftBarPackage else {
             os_log("Directory %{public}@ is not a valid packaged plugin (must end with .swiftbar)",
                    log: Log.plugin, type: .error, packageDirectory.path)
@@ -97,7 +101,9 @@ class PackagedPlugin: TimerArmingPlugin {
                 .reduce(updateInterval, min)
         }
 
-        createSupportDirs()
+        if createSupportDirectories {
+            createSupportDirs()
+        }
         os_log("Initialized packaged plugin\n%{public}@", log: Log.plugin, description)
         refresh(reason: .FirstLaunch)
     }

--- a/SwiftBar/Plugin/Plugin.swift
+++ b/SwiftBar/Plugin/Plugin.swift
@@ -66,6 +66,7 @@ typealias PluginID = String
 
 protocol Plugin: AnyObject {
     var id: PluginID { get }
+    var supportDirectoryName: String { get }
     var type: PluginType { get }
     var name: String { get }
     var file: String { get }
@@ -181,8 +182,89 @@ extension Plugin {
         }
     }
 
+    /// Support directories retain the pre-2.1 file-name contract independently
+    /// of the plugin ID. Duplicate file names therefore share support storage,
+    /// while resolved absolute IDs continue to distinguish the plugins themselves.
+    var supportDirectoryName: String {
+        (file as NSString).lastPathComponent
+    }
+
+    func supportDirectory(in baseDirectory: URL?) -> URL? {
+        guard let baseDirectory,
+              !supportDirectoryName.isEmpty,
+              supportDirectoryName != ".",
+              supportDirectoryName != "..",
+              !supportDirectoryName.contains("/"),
+              !supportDirectoryName.unicodeScalars.contains("\0")
+        else {
+            return nil
+        }
+        return baseDirectory.appendingPathComponent(supportDirectoryName, isDirectory: true)
+    }
+
+    /// Locates support data written by 2.1.x when an absolute plugin ID was
+    /// mistakenly appended below the support root. This is only a recovery
+    /// source; plugins are never given this path.
+    func regressedSupportDirectory(in baseDirectory: URL?) -> URL? {
+        guard let baseDirectory,
+              id.hasPrefix("/"),
+              !id.unicodeScalars.contains("\0")
+        else {
+            return nil
+        }
+
+        let components = id.split(separator: "/", omittingEmptySubsequences: true)
+        guard !components.isEmpty,
+              components.allSatisfy({ $0 != "." && $0 != ".." })
+        else {
+            return nil
+        }
+
+        let candidate = components.reduce(baseDirectory) {
+            $0.appendingPathComponent(String($1), isDirectory: true)
+        }
+        let resolvedBase = baseDirectory.resolvingSymlinksInPath().standardizedFileURL.path
+        let resolvedCandidate = candidate.resolvingSymlinksInPath().standardizedFileURL.path
+        guard resolvedCandidate.hasPrefix(resolvedBase + "/") else { return nil }
+        return candidate
+    }
+
+    func createSupportDirectory(in baseDirectory: URL?, fileManager: FileManager = .default) {
+        guard let directory = supportDirectory(in: baseDirectory) else { return }
+
+        if !fileManager.fileExists(atPath: directory.path),
+           let regressedDirectory = regressedSupportDirectory(in: baseDirectory)
+        {
+            var isDirectory: ObjCBool = false
+            if fileManager.fileExists(atPath: regressedDirectory.path, isDirectory: &isDirectory),
+               isDirectory.boolValue
+            {
+                let stagingDirectory = baseDirectory?.appendingPathComponent(
+                    ".swiftbar-support-recovery-\(UUID().uuidString)",
+                    isDirectory: true
+                )
+                if let stagingDirectory {
+                    defer { try? fileManager.removeItem(at: stagingDirectory) }
+                    do {
+                        try fileManager.copyItem(at: regressedDirectory, to: stagingDirectory)
+                        // Publish only a complete copy and never replace a destination
+                        // another launch or same-named plugin has already created.
+                        if !fileManager.fileExists(atPath: directory.path) {
+                            try fileManager.moveItem(at: stagingDirectory, to: directory)
+                        }
+                    } catch {
+                        // The source remains untouched; the plugin receives a new,
+                        // empty safe directory instead of a partial recovery.
+                    }
+                }
+            }
+        }
+
+        try? fileManager.createDirectory(at: directory, withIntermediateDirectories: true, attributes: nil)
+    }
+
     var cacheDirectory: URL? {
-        AppShared.cacheDirectory?.appendingPathComponent(id)
+        supportDirectory(in: AppShared.cacheDirectory)
     }
 
     var cacheDirectoryPath: String {
@@ -190,7 +272,7 @@ extension Plugin {
     }
 
     var dataDirectory: URL? {
-        AppShared.dataDirectory?.appendingPathComponent(id)
+        supportDirectory(in: AppShared.dataDirectory)
     }
 
     var dataDirectoryPath: String {
@@ -198,12 +280,8 @@ extension Plugin {
     }
 
     func createSupportDirs() {
-        if let cacheURL = cacheDirectory {
-            try? FileManager.default.createDirectory(at: cacheURL, withIntermediateDirectories: true, attributes: nil)
-        }
-        if let dataURL = dataDirectory {
-            try? FileManager.default.createDirectory(at: dataURL, withIntermediateDirectories: true, attributes: nil)
-        }
+        createSupportDirectory(in: AppShared.cacheDirectory)
+        createSupportDirectory(in: AppShared.dataDirectory)
     }
 
     var env: [String: String] {

--- a/SwiftBarTests/SwiftBarTests.swift
+++ b/SwiftBarTests/SwiftBarTests.swift
@@ -7,9 +7,10 @@ import Testing
 
 final class TestPlugin: Plugin {
     let id: PluginID
-    let type: PluginType = .Executable
+    let type: PluginType
     let name: String
     let file: String
+    let supportDirectoryNameOverride: String?
     let enabled: Bool
     var metadata: PluginMetadata?
     var contentUpdatePublisher = PassthroughSubject<String?, Never>()
@@ -23,10 +24,24 @@ final class TestPlugin: Plugin {
     var refreshEnv: [String: String] = [:]
     var terminateCallCount = 0
 
-    init(id: PluginID, file: String, content: String? = "...", enabled: Bool = true, lastState: PluginState = .Loading) {
+    var supportDirectoryName: String {
+        supportDirectoryNameOverride ?? (file as NSString).lastPathComponent
+    }
+
+    init(
+        id: PluginID,
+        file: String,
+        type: PluginType = .Executable,
+        supportDirectoryName: String? = nil,
+        content: String? = "...",
+        enabled: Bool = true,
+        lastState: PluginState = .Loading
+    ) {
         self.id = id
         self.name = id
         self.file = file
+        self.type = type
+        supportDirectoryNameOverride = supportDirectoryName
         self.content = content
         self.enabled = enabled
         self.lastState = lastState
@@ -101,6 +116,183 @@ final class TestDirectoryPluginManager: PluginManager {
 }
 
 struct SwiftBarTests {
+    @Test func supportDirectories_restoreLegacyBasenameForAbsoluteExecutableID() throws {
+        let dataRoot = URL(fileURLWithPath: "/isolated/Application Support/SwiftBar/Plugins", isDirectory: true)
+        let cacheRoot = URL(fileURLWithPath: "/isolated/Caches/com.ameba.SwiftBar/Plugins", isDirectory: true)
+        let absolutePluginPath = "/Users/example/SwiftBar/plugins/nested/weather.1m.sh"
+        let plugin = TestPlugin(id: absolutePluginPath, file: absolutePluginPath)
+
+        let dataDirectory = try #require(plugin.supportDirectory(in: dataRoot))
+        let cacheDirectory = try #require(plugin.supportDirectory(in: cacheRoot))
+
+        #expect(dataDirectory.path == dataRoot.appendingPathComponent("weather.1m.sh").path)
+        #expect(cacheDirectory.path == cacheRoot.appendingPathComponent("weather.1m.sh").path)
+        #expect(dataDirectory.lastPathComponent == cacheDirectory.lastPathComponent)
+        #expect(dataDirectory.deletingLastPathComponent().path == dataRoot.path)
+        #expect(cacheDirectory.deletingLastPathComponent().path == cacheRoot.path)
+    }
+
+    @Test func supportDirectories_useLexicalBasenameForStreamablePlugin() throws {
+        let base = URL(fileURLWithPath: "/isolated/Plugins", isDirectory: true)
+        let plugin = TestPlugin(
+            id: "stream.1m.sh",
+            file: "/Users/example/plugins/nested/stream.1m.sh",
+            type: .Streamable
+        )
+
+        #expect(try #require(plugin.supportDirectory(in: base)).path == base.appendingPathComponent("stream.1m.sh").path)
+    }
+
+    @Test func supportDirectory_rejectsUnsafeComponents() {
+        let base = URL(fileURLWithPath: "/isolated/Plugins", isDirectory: true)
+        let unsafeComponents = [
+            "/tmp/plugin.sh",
+            "../plugin.sh",
+            "nested/plugin.sh",
+            ".",
+            "..",
+            "",
+            "plugin\0.sh",
+        ]
+
+        for component in unsafeComponents {
+            let plugin = TestPlugin(id: "../../malformed-id", file: "/tmp/plugin.sh", supportDirectoryName: component)
+            #expect(plugin.supportDirectory(in: base) == nil)
+        }
+
+        let malformedIdentity = TestPlugin(id: "../../malformed-id", file: "/tmp/safe.sh")
+        #expect(malformedIdentity.supportDirectory(in: base)?.path == base.appendingPathComponent("safe.sh").path)
+    }
+
+    @Test func supportDirectory_recoversRegressedDataByCopyWithoutOverwrite() throws {
+        let tempDirectory = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
+        let base = tempDirectory.appendingPathComponent("Plugins", isDirectory: true)
+        let absolutePluginPath = "/Users/example/plugins/weather.1m.sh"
+        let regressedDirectory = base.appendingPathComponent("Users/example/plugins/weather.1m.sh", isDirectory: true)
+        try FileManager.default.createDirectory(at: regressedDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDirectory) }
+
+        let regressedData = regressedDirectory.appendingPathComponent("settings.json")
+        try Data("from-2.1".utf8).write(to: regressedData)
+
+        let plugin = TestPlugin(id: absolutePluginPath, file: absolutePluginPath)
+        plugin.createSupportDirectory(in: base)
+
+        let compatibleDirectory = try #require(plugin.supportDirectory(in: base))
+        let compatibleData = compatibleDirectory.appendingPathComponent("settings.json")
+        #expect(try String(contentsOf: compatibleData, encoding: .utf8) == "from-2.1")
+        #expect(FileManager.default.fileExists(atPath: regressedData.path))
+
+        try Data("newer-regressed-value".utf8).write(to: regressedData)
+        plugin.createSupportDirectory(in: base)
+
+        #expect(try String(contentsOf: compatibleData, encoding: .utf8) == "from-2.1")
+        #expect(try String(contentsOf: regressedData, encoding: .utf8) == "newer-regressed-value")
+    }
+
+    @Test func supportDirectory_doesNotPublishPartialRecoveryAfterCopyFailure() throws {
+        let tempDirectory = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
+        let base = tempDirectory.appendingPathComponent("Plugins", isDirectory: true)
+        let absolutePluginPath = "/Users/example/plugins/weather.1m.sh"
+        let regressedDirectory = base.appendingPathComponent("Users/example/plugins/weather.1m.sh", isDirectory: true)
+        try FileManager.default.createDirectory(at: regressedDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDirectory) }
+
+        let regularFile = regressedDirectory.appendingPathComponent("a-settings.json")
+        try Data("settings".utf8).write(to: regularFile)
+        let unsupportedFile = regressedDirectory.appendingPathComponent("z-fifo")
+        try #require(mkfifo(unsupportedFile.path, 0o600) == 0)
+
+        let plugin = TestPlugin(id: absolutePluginPath, file: absolutePluginPath)
+        plugin.createSupportDirectory(in: base)
+
+        let compatibleDirectory = try #require(plugin.supportDirectory(in: base))
+        #expect(try FileManager.default.contentsOfDirectory(atPath: compatibleDirectory.path).isEmpty)
+        #expect(FileManager.default.fileExists(atPath: regularFile.path))
+        #expect(FileManager.default.fileExists(atPath: unsupportedFile.path))
+        #expect(try FileManager.default.contentsOfDirectory(atPath: base.path).allSatisfy {
+            !$0.hasPrefix(".swiftbar-support-recovery-")
+        })
+    }
+
+    @Test func executablePlugin_preservesResolvedIdentityAndLegacySupportNameForSymlink() throws {
+        let tempDirectory = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDirectory) }
+
+        let targetURL = tempDirectory.appendingPathComponent("target.1m.sh")
+        try Data("#!/bin/zsh\necho target\n".utf8).write(to: targetURL)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: targetURL.path)
+
+        let aliasURL = tempDirectory.appendingPathComponent("alias.1m.sh")
+        try FileManager.default.createSymbolicLink(atPath: aliasURL.path, withDestinationPath: targetURL.path)
+
+        let plugin = ExecutablePlugin(fileURL: aliasURL, createSupportDirectories: false)
+        plugin.operation?.cancel()
+        plugin.operation?.waitUntilFinished()
+        defer { plugin.terminate() }
+
+        #expect(plugin.id == targetURL.resolvingSymlinksInPath().path)
+        #expect(plugin.supportDirectoryName == aliasURL.lastPathComponent)
+    }
+
+    @Test func executablePlugins_withDuplicateFilenamesKeepDistinctIDsAndCompatibleSupportName() throws {
+        let tempDirectory = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
+        let firstDirectory = tempDirectory.appendingPathComponent("first", isDirectory: true)
+        let secondDirectory = tempDirectory.appendingPathComponent("second", isDirectory: true)
+        try FileManager.default.createDirectory(at: firstDirectory, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: secondDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDirectory) }
+
+        let firstURL = firstDirectory.appendingPathComponent("duplicate.1m.sh")
+        let secondURL = secondDirectory.appendingPathComponent("duplicate.1m.sh")
+        for url in [firstURL, secondURL] {
+            try Data("#!/bin/zsh\necho duplicate\n".utf8).write(to: url)
+            try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
+        }
+
+        let firstPlugin = ExecutablePlugin(fileURL: firstURL, createSupportDirectories: false)
+        let secondPlugin = ExecutablePlugin(fileURL: secondURL, createSupportDirectories: false)
+        for plugin in [firstPlugin, secondPlugin] {
+            plugin.operation?.cancel()
+            plugin.operation?.waitUntilFinished()
+        }
+        defer {
+            firstPlugin.terminate()
+            secondPlugin.terminate()
+        }
+
+        #expect(firstPlugin.id != secondPlugin.id)
+        #expect(firstPlugin.id == firstURL.resolvingSymlinksInPath().path)
+        #expect(secondPlugin.id == secondURL.resolvingSymlinksInPath().path)
+        #expect(firstPlugin.supportDirectoryName == "duplicate.1m.sh")
+        #expect(secondPlugin.supportDirectoryName == "duplicate.1m.sh")
+    }
+
+    @Test func packagedPlugin_usesResolvedIdentityAndPackageBasenameForSupportDirectory() throws {
+        let tempDirectory = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
+        let packageTargetURL = tempDirectory.appendingPathComponent("package-target", isDirectory: true)
+        try FileManager.default.createDirectory(at: packageTargetURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDirectory) }
+
+        let executableURL = packageTargetURL.appendingPathComponent("plugin.sh")
+        try Data("#!/bin/zsh\necho packaged\n".utf8).write(to: executableURL)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executableURL.path)
+
+        let packageAliasURL = tempDirectory.appendingPathComponent("weather.swiftbar", isDirectory: true)
+        try FileManager.default.createSymbolicLink(atPath: packageAliasURL.path, withDestinationPath: packageTargetURL.path)
+
+        let plugin = try #require(PackagedPlugin(packageDirectory: packageAliasURL, createSupportDirectories: false))
+        plugin.operation?.cancel()
+        plugin.operation?.waitUntilFinished()
+        defer { plugin.terminate() }
+
+        let base = URL(fileURLWithPath: "/isolated/Plugins", isDirectory: true)
+        #expect(plugin.id == packageTargetURL.resolvingSymlinksInPath().path)
+        #expect(plugin.supportDirectoryName == "weather.swiftbar")
+        #expect(try #require(plugin.supportDirectory(in: base)).path == base.appendingPathComponent("weather.swiftbar").path)
+    }
+
     @Test func testSwiftBarPackageDetection_usesPathExtension() {
         let barePluginRoot = URL(fileURLWithPath: "/tmp/.swiftbar", isDirectory: true)
         let package = URL(fileURLWithPath: "/tmp/weather.swiftbar", isDirectory: true)


### PR DESCRIPTION
## Problem

`5e7845b` changed executable plugin IDs from a filename to a resolved absolute path. Support directories still appended that ID as a path component, so SwiftBar 2.1.x exposed paths such as `.../Plugins/Users/.../plugin.sh` and stopped reading the basename directories used through 2.0.1.

## Fix

- keep resolved absolute plugin IDs for duplicate-name and symlink identity
- derive data/cache support directories from a validated lexical filename component
- use the package directory name for packaged plugins
- recover 2.1.x data and cache with a staged, copy-only migration when the safe destination does not exist
- never delete the regressed source or overwrite/merge an existing destination

Duplicate filenames still share support storage, matching the pre-2.1 contract, while their runtime IDs remain distinct. Old 2.1.x nested directories are intentionally left in place after recovery.

## Validation

- reproduced with released 2.0.1 (build 536), 2.1.0 (build 594), 2.1.1 (build 597), and pre-fix `origin/main`
- exercised the fixed built app with real executable plugins and an isolated home; verified basename paths, existing 2.0.1 data, 2.1.x data/cache recovery, and preserved recovery sources
- focused support-path tests: 8 passed
- full `xcodebuild` suite: 206 passed, 0 failed, 0 skipped
- mutations reverting path selection and recovery behavior failed the discriminating tests
- `git diff --check` passed
- final Codex review: no actionable findings

Closes #522
