### PR TITLE
fix(menu): preserve attributed titles during hover

### DIFF
--- a/SwiftBar/MenuBar/MenuBarItem.swift
+++ b/SwiftBar/MenuBar/MenuBarItem.swift
@@ -60,6 +60,7 @@ class MenubarItem: NSObject {
     /// NSMenuItems injected as fold children, keyed by parent NSMenuItem identity.
     private var foldChildItems: [ObjectIdentifier: [NSMenuItem]] = [:]
     private weak var highlightedFoldItem: NSMenuItem?
+    private weak var highlightedAttributedTitleItem: NSMenuItem?
 
     private var aboutPopover = NSPopover()
     private var errorPopover = NSPopover()
@@ -240,6 +241,7 @@ extension MenubarItem: NSMenuDelegate {
             foldView.setHighlighted(false)
         }
         highlightedFoldItem = nil
+        clearTrackedAttributedTitleHighlight()
 
         // if plugin was refreshed when menu was opened refresh on menu close
         if refreshOnClose {
@@ -254,20 +256,31 @@ extension MenubarItem: NSMenuDelegate {
     }
 
     func menu(_ menu: NSMenu, willHighlight item: NSMenuItem?) {
-        if let highlitedItem = menu.highlightedItem,
-           highlitedItem.attributedTitle != nil,
-           let params = highlitedItem.representedObject as? MenuLineParameters,
-           params.color != nil
-        {
-            highlitedItem.attributedTitle = atributedTitle(with: params).title
-        }
+        if Self.shouldRewriteAttributedTitlesDuringMenuTracking() {
+            if let highlitedItem = menu.highlightedItem,
+               highlitedItem.attributedTitle != nil,
+               let params = highlitedItem.representedObject as? MenuLineParameters,
+               params.color != nil
+            {
+                highlitedItem.attributedTitle = atributedTitle(with: params).title
+            }
 
-        if var params = item?.representedObject as? MenuLineParameters,
-           item?.attributedTitle != nil,
-           params.color != nil
-        {
-            params.params.removeValue(forKey: "color")
-            item?.attributedTitle = atributedTitle(with: params).title
+            if var params = item?.representedObject as? MenuLineParameters,
+               item?.attributedTitle != nil,
+               params.color != nil
+            {
+                params.params.removeValue(forKey: "color")
+                item?.attributedTitle = atributedTitle(with: params).title
+            }
+        } else {
+            clearTrackedAttributedTitleHighlight()
+
+            if let item,
+               let title = item.attributedTitle as? MenuTrackingAttributedTitle
+            {
+                title.isHighlighted = true
+                highlightedAttributedTitleItem = item
+            }
         }
 
         if let previousFoldView = highlightedFoldItem?.view as? FoldableMenuItemView {
@@ -279,6 +292,19 @@ extension MenubarItem: NSMenuDelegate {
         } else {
             highlightedFoldItem = nil
         }
+    }
+
+    static func shouldRewriteAttributedTitlesDuringMenuTracking(
+        on operatingSystemVersion: OperatingSystemVersion = ProcessInfo.processInfo.operatingSystemVersion
+    ) -> Bool {
+        // Replacing an attributed title while AppKit is tracking a macOS 26+
+        // menu can clip its final row. It also removes inline image attachments.
+        operatingSystemVersion.majorVersion < 26
+    }
+
+    private func clearTrackedAttributedTitleHighlight() {
+        (highlightedAttributedTitleItem?.attributedTitle as? MenuTrackingAttributedTitle)?.isHighlighted = false
+        highlightedAttributedTitleItem = nil
     }
 }
 
@@ -1052,7 +1078,12 @@ extension MenubarItem {
             item.attributedTitle = title
             item.image = image
         case .attributed:
-            item.attributedTitle = menuTitle(title, image: image)
+            let titleWithImage = menuTitle(title, image: image)
+            item.attributedTitle = if params.color != nil, !params.ansi {
+                MenuTrackingAttributedTitle(titleWithImage)
+            } else {
+                titleWithImage
+            }
             item.image = nil
         }
     }
@@ -1692,6 +1723,42 @@ extension MenubarItem {
     @objc func perfomMenutItemAction(_ sender: NSMenuItem) {
         guard let params = sender.representedObject as? MenuLineParameters else { return }
         performItemAction(params: params)
+    }
+}
+
+private final class MenuTrackingAttributedTitle: NSAttributedString {
+    private let backing: NSAttributedString
+    var isHighlighted = false
+
+    init(_ backing: NSAttributedString) {
+        self.backing = backing
+        super.init()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    @available(*, unavailable)
+    required init?(pasteboardPropertyList propertyList: Any, ofType type: NSPasteboard.PasteboardType) {
+        fatalError("init(pasteboardPropertyList:ofType:) has not been implemented")
+    }
+
+    override var string: String {
+        backing.string
+    }
+
+    override func attributes(at location: Int, effectiveRange range: NSRangePointer?) -> [NSAttributedString.Key: Any] {
+        var attributes = backing.attributes(at: location, effectiveRange: range)
+        if isHighlighted {
+            attributes[.foregroundColor] = NSColor.selectedMenuItemTextColor
+        }
+        return attributes
+    }
+
+    override func copy(with zone: NSZone? = nil) -> Any {
+        self
     }
 }
 

--- a/SwiftBarTests/SwiftBarTests.swift
+++ b/SwiftBarTests/SwiftBarTests.swift
@@ -3553,6 +3553,81 @@ struct FoldMenuItemBuildTests {
         #expect(nativeImage.isTemplate)
     }
 
+    @MainActor @Test func testPlainHighlightPreservesMenuItemsAndAttributedTitlesOnMacOS26AndLater() throws {
+        guard !MenubarItem.shouldRewriteAttributedTitlesDuringMenuTracking() else { return }
+
+        let item = makeMenuBarItem()
+        item.plugin?.metadata = PluginMetadata(name: "Issue 519 Probe")
+        item._updateMenu(content: """
+        Title
+        ---
+        Colored | color=#0a0a14 refresh=true
+        Alternate | color=#0a0a14 refresh=true alternate=true
+        """)
+
+        let highlightedItem = try #require(menuItem(named: "Colored", in: item.statusBarMenu))
+        let alternateItem = try #require(menuItem(named: "Alternate", in: item.statusBarMenu))
+        let originalItems = item.statusBarMenu.items
+        let originalTitles = originalItems.map(\.attributedTitle)
+        let finalItem = try #require(originalItems.last)
+        #expect(finalItem === item.aboutItem)
+
+        item.menu(item.statusBarMenu, willHighlight: highlightedItem)
+        #expect(highlightedItem.attributedTitle?.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor == .selectedMenuItemTextColor)
+        item.menuDidClose(item.statusBarMenu)
+
+        #expect(item.statusBarMenu.items.count == originalItems.count)
+        #expect(zip(item.statusBarMenu.items, originalItems).allSatisfy { $0 === $1 })
+        #expect(zip(item.statusBarMenu.items.map(\.attributedTitle), originalTitles).allSatisfy { $0 === $1 })
+        #expect(item.statusBarMenu.items.last === finalItem)
+        #expect(highlightedItem.attributedTitle?.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor == NSColor.webColor(from: "#0a0a14"))
+        #expect((highlightedItem.representedObject as? MenuLineParameters)?.refresh == true)
+        #expect(highlightedItem.action == #selector(MenubarItem.perfomMenutItemAction))
+        #expect(highlightedItem.target === item)
+        #expect(alternateItem.isAlternate)
+        #expect(alternateItem.action == #selector(MenubarItem.perfomMenutItemAction))
+        #expect(alternateItem.target === item)
+    }
+
+    @Test func testHighlightTitleRewriteStopsAtMacOS26Boundary() {
+        #expect(MenubarItem.shouldRewriteAttributedTitlesDuringMenuTracking(
+            on: OperatingSystemVersion(majorVersion: 15, minorVersion: 6, patchVersion: 0)
+        ))
+        #expect(!MenubarItem.shouldRewriteAttributedTitlesDuringMenuTracking(
+            on: OperatingSystemVersion(majorVersion: 26, minorVersion: 0, patchVersion: 0)
+        ))
+        #expect(!MenubarItem.shouldRewriteAttributedTitlesDuringMenuTracking(
+            on: OperatingSystemVersion(majorVersion: 27, minorVersion: 0, patchVersion: 0)
+        ))
+    }
+
+    @MainActor @Test func testPlainHighlightPreservesAttributedImageOnMacOS26AndLater() throws {
+        guard !MenubarItem.shouldRewriteAttributedTitlesDuringMenuTracking() else { return }
+
+        let item = makeMenuBarItem()
+        let image = try makeBase64PNG(size: NSSize(width: 30, height: 30), color: .systemBlue)
+        item._updateMenu(content: """
+        Title
+        ---
+        Image\\nsubtitle | color=#0a0a14 image=\(image) refresh=true
+        Alternate\\nsubtitle | color=#0a0a14 image=\(image) refresh=true alternate=true
+        """)
+
+        let imageItem = try #require(menuItem(named: "Image\\nsubtitle", in: item.statusBarMenu))
+        let originalTitle = try #require(imageItem.attributedTitle)
+        let originalImage = try attachedImage(from: imageItem)
+        let textLocation = (originalTitle.string as NSString).range(of: "Image").location
+
+        item.menu(item.statusBarMenu, willHighlight: imageItem)
+        #expect(imageItem.attributedTitle?.attribute(.foregroundColor, at: textLocation, effectiveRange: nil) as? NSColor == .selectedMenuItemTextColor)
+        item.menu(item.statusBarMenu, willHighlight: nil)
+
+        #expect(imageItem.attributedTitle === originalTitle)
+        #expect(try attachedImage(from: imageItem) === originalImage)
+        #expect(imageItem.attributedTitle?.attribute(.foregroundColor, at: textLocation, effectiveRange: nil) as? NSColor == NSColor.webColor(from: "#0a0a14"))
+        #expect(imageItem.image == nil)
+    }
+
     @MainActor @Test func testFullBuild_foldItemStartsCollapsed() throws {
         let item = makeMenuBarItem()
 


### PR DESCRIPTION
## Summary

- keep macOS 26+ menu item title objects stable during menu tracking
- preserve Base64 title attachments and custom-color selected contrast
- retain the existing title replacement path before macOS 26
- clear tracked highlight state on menu close, including macOS 26.0–26.3

## Root cause

SwiftBar replaced colored `NSMenuItem.attributedTitle` values from `menu(_:willHighlight:)`. On the reporter's macOS 26.5.2 build, changing that property while AppKit tracks the menu invalidates the menu window and clips its final rendered row. The menu model still contains the same item objects, which explains why SwiftBar's own About item can appear to disappear based only on its final position.

The same replacement rebuilt the title from `MenuLineParameters` without the macOS 26+ inline `NSTextAttachment`, so Base64 images disappeared and the text shifted left.

macOS 26+ now keeps the attributed title object unchanged. A small `NSAttributedString` wrapper returns the semantic selected text color during highlighting without assigning the property. The existing pre-26 behavior remains unchanged.

## Evidence

- reviewed the reporter's macOS 26.5.2/build 25F84 recording and separated the final-row clipping from attachment loss
- direct AppKit tracking probe confirmed callback order and selected-state rendering
- regression probes assert menu item count and identity, final About identity, attributed-title identity, attachment image identity, alternate state, and refresh action ownership
- fault mutations that restore title replacement fail both symptom probes
- removing the close reset fails the macOS 26.0–26.3 lifecycle assertion

## Validation

- focused `FoldMenuItemBuildTests`: 21 passed
- full macOS test suite: passed
- universal Release build, arm64 + x86_64: passed
- final Codex review: no actionable findings
- umputun maintainer gate: passed

The exact macOS 26.5.2 installation and reporter production plugin are unavailable locally. Validation ran on macOS 27.0 beta; the state-level probes cover the failing callback and mutation directly, while the reporter recording supplies the macOS 26.5.2 visual evidence.

Closes #519
