### PR TITLE
fix(menu): preserve sfconfig symbol colors

### DIFF
--- a/SwiftBar/MenuBar/MenuLineParameters.swift
+++ b/SwiftBar/MenuBar/MenuLineParameters.swift
@@ -332,13 +332,14 @@ struct MenuLineParameters: Codable, Equatable {
                 guard let finalSymbol = symbolToUse else { return nil }
 
                 let sfmc = getSFConfig()
+                let configuredColors = sfmc?.getColors() ?? []
                 var config = NSImage.SymbolConfiguration(scale: .large)
                 if #available(OSX 12.0, *), let sfmc {
                     switch sfmc.renderingMode {
                     case .Hierarchical:
-                        config = config.applying(NSImage.SymbolConfiguration(hierarchicalColor: sfmc.getColors().first ?? NSColor(Color.primary)))
+                        config = config.applying(NSImage.SymbolConfiguration(hierarchicalColor: configuredColors.first ?? NSColor(Color.primary)))
                     case .Palette:
-                        config = config.applying(NSImage.SymbolConfiguration(paletteColors: sfmc.getColors()))
+                        config = config.applying(NSImage.SymbolConfiguration(paletteColors: configuredColors))
                     }
                     config = config.applying(NSImage.SymbolConfiguration(pointSize: 0, weight: sfmc.getWeight(), scale: sfmc.getScale()))
                 }
@@ -355,7 +356,7 @@ struct MenuLineParameters: Codable, Equatable {
                     image = NSImage(systemSymbolName: finalSymbol, accessibilityDescription: nil)?.withSymbolConfiguration(config)
                 }
 
-                image?.isTemplate = sfmc == nil
+                image?.isTemplate = configuredColors.isEmpty
                 return resizedImageIfRequested(image)
             }
         }

--- a/SwiftBar/MenuBar/MenuLineParameters.swift
+++ b/SwiftBar/MenuBar/MenuLineParameters.swift
@@ -355,7 +355,7 @@ struct MenuLineParameters: Codable, Equatable {
                     image = NSImage(systemSymbolName: finalSymbol, accessibilityDescription: nil)?.withSymbolConfiguration(config)
                 }
 
-                image?.isTemplate = true
+                image?.isTemplate = sfmc == nil
                 return resizedImageIfRequested(image)
             }
         }

--- a/SwiftBarTests/SwiftBarTests.swift
+++ b/SwiftBarTests/SwiftBarTests.swift
@@ -3332,6 +3332,14 @@ struct FoldMenuItemBuildTests {
         return pngData.base64EncodedString()
     }
 
+    private func sfConfig(renderingMode: String, colors: [String]) throws -> String {
+        let data = try JSONSerialization.data(withJSONObject: [
+            "renderingMode": renderingMode,
+            "colors": colors,
+        ])
+        return data.base64EncodedString()
+    }
+
     @MainActor
     private func attachmentCell(from item: NSMenuItem) throws -> NSTextAttachmentCell {
         let title = try #require(item.attributedTitle)
@@ -3363,6 +3371,38 @@ struct FoldMenuItemBuildTests {
         canvas.unlockFocus()
 
         return try #require(canvas.tiffRepresentation)
+    }
+
+    @MainActor
+    private func renderedImage(
+        _ image: NSImage,
+        appearance: NSAppearance.Name
+    ) throws -> Data {
+        let canvas = NSImage(size: NSSize(width: 20, height: 20))
+        let drawImage = {
+            NSColor.clear.setFill()
+            NSRect(origin: .zero, size: canvas.size).fill()
+            image.draw(in: NSRect(x: 2, y: 2, width: 16, height: 16))
+        }
+
+        canvas.lockFocus()
+        if let drawingAppearance = NSAppearance(named: appearance) {
+            drawingAppearance.performAsCurrentDrawingAppearance(drawImage)
+        } else {
+            drawImage()
+        }
+        canvas.unlockFocus()
+
+        return try #require(canvas.tiffRepresentation)
+    }
+
+    @MainActor
+    private func menuItem(attaching image: NSImage) -> NSMenuItem {
+        let item = NSMenuItem()
+        item.attributedTitle = NSAttributedString(
+            attachment: .centeredMenuImage(with: image, and: .menuFont(ofSize: 0))
+        )
+        return item
     }
 
     @MainActor @Test func testFullBuild_preservesReporterImagePointSizeOnMacOS26AndLater() throws {
@@ -3506,6 +3546,100 @@ struct FoldMenuItemBuildTests {
         }
     }
 
+    @MainActor @Test func testSFConfigImagesRemainColoredWhilePlainAndInvalidConfigsRemainTemplates() throws {
+        let palette = try sfConfig(renderingMode: "Palette", colors: ["#FF3B30", "#34C759"])
+        let hierarchical = try sfConfig(renderingMode: "Hierarchical", colors: ["#AF52DE"])
+
+        for config in [palette, hierarchical] {
+            let image = try #require(MenuLineParameters(
+                line: "Image | sfimage=inset.filled.circle sfconfig=\(config) width=20 height=20"
+            ).image)
+            #expect(!image.isTemplate)
+        }
+
+        for line in [
+            "Image | sfimage=inset.filled.circle",
+            "Image | sfimage=inset.filled.circle sfconfig=not-base64",
+            "Image | sfimage=inset.filled.circle sfconfig=e30=",
+        ] {
+            #expect(try #require(MenuLineParameters(line: line).image).isTemplate)
+        }
+    }
+
+    @MainActor @Test func testFullBuildAndIncrementalRefreshPreserveSFConfigRendering() throws {
+        let item = makeMenuBarItem()
+        let palette = try sfConfig(renderingMode: "Palette", colors: ["#FF3B30", "#34C759"])
+        let hierarchical = try sfConfig(renderingMode: "Hierarchical", colors: ["#AF52DE"])
+
+        item._updateMenu(content: """
+        Title
+        ---
+        Image | sfimage=inset.filled.circle sfconfig=\(palette)
+        """)
+
+        let originalItem = try #require(menuItem(named: "Image", in: item.statusBarMenu))
+        if #available(macOS 26.0, *) {
+            let paletteImage = try #require((originalItem.representedObject as? MenuLineParameters)?.image)
+            for appearance in [NSAppearance.Name.aqua, .darkAqua] {
+                let expected = try renderedImage(paletteImage, appearance: appearance)
+                #expect(try renderedAttachment(from: originalItem, appearance: appearance, highlighted: false) == expected)
+                #expect(try renderedAttachment(from: originalItem, appearance: appearance, highlighted: true) == expected)
+            }
+        }
+
+        item._updateMenu(content: """
+        Title
+        ---
+        Image | sfimage=inset.filled.circle sfconfig=\(hierarchical)
+        """)
+
+        let refreshedItem = try #require(menuItem(named: "Image", in: item.statusBarMenu))
+        #expect(refreshedItem === originalItem)
+        if #available(macOS 26.0, *) {
+            let hierarchicalImage = try #require((refreshedItem.representedObject as? MenuLineParameters)?.image)
+            let expected = try renderedImage(hierarchicalImage, appearance: .aqua)
+            #expect(try renderedAttachment(from: refreshedItem, appearance: .aqua, highlighted: false) == expected)
+            #expect(try renderedAttachment(from: refreshedItem, appearance: .aqua, highlighted: true) == expected)
+        }
+    }
+
+    @MainActor @Test func testAttributedColorBase64ImageIgnoresAppearanceAndHighlightTint() throws {
+        let colorImage = try makeBase64PNG(size: NSSize(width: 16, height: 16), color: .systemRed)
+        let params = MenuLineParameters(line: "Image | image=\(colorImage)")
+        let menuItem = NSMenuItem()
+
+        makeMenuBarItem().configureMenuImage(
+            on: menuItem,
+            title: NSAttributedString(string: "Image"),
+            params: params,
+            presentation: .attributed
+        )
+
+        let image = try attachedImage(from: menuItem)
+        #expect(!image.isTemplate)
+        for appearance in [NSAppearance.Name.aqua, .darkAqua] {
+            let expected = try renderedImage(image, appearance: appearance)
+            #expect(try renderedAttachment(from: menuItem, appearance: appearance, highlighted: false) == expected)
+            #expect(try renderedAttachment(from: menuItem, appearance: appearance, highlighted: true) == expected)
+        }
+    }
+
+    @MainActor @Test func testAttributedMulticolorSymbolIgnoresAppearanceAndHighlightTint() throws {
+        let configuration = NSImage.SymbolConfiguration.preferringMulticolor()
+        let image = try #require(
+            NSImage(systemSymbolName: "externaldrive.badge.icloud", accessibilityDescription: nil)?
+                .withSymbolConfiguration(configuration)
+        )
+        #expect(!image.isTemplate)
+        let menuItem = menuItem(attaching: image)
+
+        for appearance in [NSAppearance.Name.aqua, .darkAqua] {
+            let expected = try renderedImage(image, appearance: appearance)
+            #expect(try renderedAttachment(from: menuItem, appearance: appearance, highlighted: false) == expected)
+            #expect(try renderedAttachment(from: menuItem, appearance: appearance, highlighted: true) == expected)
+        }
+    }
+
     @MainActor @Test func testAttributedTemplateImageSupportsAppearanceAndHighlightTint() throws {
         let item = makeMenuBarItem()
         let image = try makeBase64PNG(size: NSSize(width: 16, height: 16))
@@ -3551,6 +3685,19 @@ struct FoldMenuItemBuildTests {
         let nativeImage = try #require(menuItem.image)
         #expect(nativeImage.size == NSSize(width: 27, height: 27))
         #expect(nativeImage.isTemplate)
+
+        let palette = try sfConfig(renderingMode: "Palette", colors: ["#FF3B30", "#34C759"])
+        let coloredParams = MenuLineParameters(
+            line: "Image | sfimage=inset.filled.circle sfconfig=\(palette)"
+        )
+        let coloredItem = NSMenuItem()
+        item.configureMenuImage(
+            on: coloredItem,
+            title: NSAttributedString(string: "Image"),
+            params: coloredParams,
+            presentation: .native
+        )
+        #expect(try !#require(coloredItem.image).isTemplate)
     }
 
     @MainActor @Test func testPlainHighlightPreservesMenuItemsAndAttributedTitlesOnMacOS26AndLater() throws {

--- a/SwiftBarTests/SwiftBarTests.swift
+++ b/SwiftBarTests/SwiftBarTests.swift
@@ -3549,6 +3549,8 @@ struct FoldMenuItemBuildTests {
     @MainActor @Test func testSFConfigImagesRemainColoredWhilePlainAndInvalidConfigsRemainTemplates() throws {
         let palette = try sfConfig(renderingMode: "Palette", colors: ["#FF3B30", "#34C759"])
         let hierarchical = try sfConfig(renderingMode: "Hierarchical", colors: ["#AF52DE"])
+        let colorlessHierarchical = try sfConfig(renderingMode: "Hierarchical", colors: [])
+        let invalidColorHierarchical = try sfConfig(renderingMode: "Hierarchical", colors: ["not-a-color"])
 
         for config in [palette, hierarchical] {
             let image = try #require(MenuLineParameters(
@@ -3561,9 +3563,28 @@ struct FoldMenuItemBuildTests {
             "Image | sfimage=inset.filled.circle",
             "Image | sfimage=inset.filled.circle sfconfig=not-base64",
             "Image | sfimage=inset.filled.circle sfconfig=e30=",
+            "Image | sfimage=inset.filled.circle sfconfig=\(colorlessHierarchical) width=20 height=20",
+            "Image | sfimage=inset.filled.circle sfconfig=\(invalidColorHierarchical) width=20 height=20",
         ] {
             #expect(try #require(MenuLineParameters(line: line).image).isTemplate)
         }
+
+        let item = makeMenuBarItem()
+        let params = MenuLineParameters(
+            line: "Image | sfimage=inset.filled.circle sfconfig=\(colorlessHierarchical) width=20 height=20"
+        )
+        let menuItem = NSMenuItem()
+        item.configureMenuImage(
+            on: menuItem,
+            title: NSAttributedString(string: "Image"),
+            params: params,
+            presentation: .attributed
+        )
+        let aqua = try renderedAttachment(from: menuItem, appearance: .aqua, highlighted: false)
+        let darkAqua = try renderedAttachment(from: menuItem, appearance: .darkAqua, highlighted: false)
+        let highlighted = try renderedAttachment(from: menuItem, appearance: .aqua, highlighted: true)
+        #expect(aqua != darkAqua)
+        #expect(aqua != highlighted)
     }
 
     @MainActor @Test func testFullBuildAndIncrementalRefreshPreserveSFConfigRendering() throws {


### PR DESCRIPTION
## Summary

- preserve explicit `sfconfig` palette, hierarchical, and multicolor rendering in macOS 26 attributed menu attachments
- retain template tinting and highlight behavior for plain symbols and configurations without a usable explicit color
- add rendered-output coverage for initial and incremental menus, light/dark appearances, highlight states, Base64 images, and the legacy native-image path

## Root cause

The symbol builder unconditionally marked configured SF Symbols as template images. The macOS 26 attachment cell correctly tints templates while drawing, so it painted over the palette colors requested by `sfconfig`.

Symbols with at least one usable explicit color are now non-template. Plain symbols and decoded configurations without a usable color remain templates and continue to receive normal menu tinting.

## Validation

- reproduced on current `main`: 22/25 focused tests passed, with all three regression cases failing
- fixed focused suite: 25/25 passed
- full suite: 216/216 passed
- universal Release build: `arm64` and `x86_64`
- adversarial mutations verified both sides of the template/non-template contract
- Codex review found and fixed the colorless hierarchical fallback case; final review is clean
- umputun maintainer gate: no actionable findings

Closes #532