### PR TITLE
fix(menu): correct inline image alignment and hover redraw

### DIFF
--- a/SwiftBar/MenuBar/MenuBarItem.swift
+++ b/SwiftBar/MenuBar/MenuBarItem.swift
@@ -1097,8 +1097,26 @@ extension MenubarItem {
         let font = title.length > 0 ? title.attribute(.font, at: 0, effectiveRange: nil) as? NSFont : nil
         let menuFont = font ?? .menuFont(ofSize: 0)
         let result = NSMutableAttributedString(attachment: .centeredMenuImage(with: image, and: menuFont))
-        result.append(NSAttributedString(string: "  "))
+        let spacing = "  "
+        result.append(NSAttributedString(string: spacing, attributes: [.font: menuFont]))
         result.append(title)
+
+        let paragraphStyle = (title.length > 0
+            ? title.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSParagraphStyle
+            : nil)?.mutableCopy() as? NSMutableParagraphStyle ?? NSMutableParagraphStyle()
+        paragraphStyle.headIndent = image.size.width + (spacing as NSString).size(withAttributes: [.font: menuFont]).width
+        result.addAttribute(.paragraphStyle, value: paragraphStyle, range: NSRange(location: 0, length: result.length))
+
+        let firstLineBreak = (result.string as NSString).range(of: "\n")
+        if firstLineBreak.location != NSNotFound, NSMaxRange(firstLineBreak) < result.length {
+            let continuationStyle = paragraphStyle.mutableCopy() as? NSMutableParagraphStyle ?? NSMutableParagraphStyle()
+            continuationStyle.firstLineHeadIndent = paragraphStyle.headIndent
+            let continuationRange = NSRange(
+                location: NSMaxRange(firstLineBreak),
+                length: result.length - NSMaxRange(firstLineBreak)
+            )
+            result.addAttribute(.paragraphStyle, value: continuationStyle, range: continuationRange)
+        }
         return result
     }
 

--- a/SwiftBar/MenuBar/MenuBarItem.swift
+++ b/SwiftBar/MenuBar/MenuBarItem.swift
@@ -61,6 +61,7 @@ class MenubarItem: NSObject {
     private var foldChildItems: [ObjectIdentifier: [NSMenuItem]] = [:]
     private weak var highlightedFoldItem: NSMenuItem?
     private weak var highlightedAttributedTitleItem: NSMenuItem?
+    private var highlightedAttributedTitle: MenuTrackingAttributedTitle?
 
     private var aboutPopover = NSPopover()
     private var errorPopover = NSPopover()
@@ -273,13 +274,14 @@ extension MenubarItem: NSMenuDelegate {
                 item?.attributedTitle = atributedTitle(with: params).title
             }
         } else {
-            clearTrackedAttributedTitleHighlight()
-
-            if let item,
-               let title = item.attributedTitle as? MenuTrackingAttributedTitle
-            {
-                title.isHighlighted = true
-                highlightedAttributedTitleItem = item
+            let trackedTitle = item?.attributedTitle as? MenuTrackingAttributedTitle
+            if highlightedAttributedTitleItem !== item || highlightedAttributedTitle !== trackedTitle {
+                clearTrackedAttributedTitleHighlight()
+                if let item, let trackedTitle {
+                    setTrackedAttributedTitleHighlight(trackedTitle, on: item, to: true)
+                    highlightedAttributedTitleItem = item
+                    highlightedAttributedTitle = trackedTitle
+                }
             }
         }
 
@@ -303,8 +305,20 @@ extension MenubarItem: NSMenuDelegate {
     }
 
     private func clearTrackedAttributedTitleHighlight() {
-        (highlightedAttributedTitleItem?.attributedTitle as? MenuTrackingAttributedTitle)?.isHighlighted = false
+        if let item = highlightedAttributedTitleItem, let title = highlightedAttributedTitle {
+            setTrackedAttributedTitleHighlight(title, on: item, to: false)
+        }
         highlightedAttributedTitleItem = nil
+        highlightedAttributedTitle = nil
+    }
+
+    private func setTrackedAttributedTitleHighlight(
+        _ title: MenuTrackingAttributedTitle,
+        on item: NSMenuItem,
+        to highlighted: Bool
+    ) {
+        title.isHighlighted = highlighted
+        item.menu?.itemChanged(item)
     }
 }
 

--- a/SwiftBarTests/SwiftBarTests.swift
+++ b/SwiftBarTests/SwiftBarTests.swift
@@ -3255,6 +3255,16 @@ struct FoldParameterTests {
 
 struct FoldMenuItemBuildTests {
     @MainActor
+    private final class TrackingMenu: NSMenu {
+        var changedItems: [NSMenuItem] = []
+
+        override func itemChanged(_ item: NSMenuItem) {
+            changedItems.append(item)
+            super.itemChanged(item)
+        }
+    }
+
+    @MainActor
     private func makeMenuBarItem() -> MenubarItem {
         let plugin = TestPlugin(id: "test-plugin", file: "/tmp/test-plugin.5s.sh", content: nil, lastState: .Success)
         let item = MenubarItem(title: "Test")
@@ -3646,6 +3656,66 @@ struct FoldMenuItemBuildTests {
         #expect(alternateItem.isAlternate)
         #expect(alternateItem.action == #selector(MenubarItem.perfomMenutItemAction))
         #expect(alternateItem.target === item)
+    }
+
+    @MainActor @Test func testPlainHighlightInvalidatesTrackedColorWithoutReplacingTitle() throws {
+        guard !MenubarItem.shouldRewriteAttributedTitlesDuringMenuTracking() else { return }
+
+        let item = makeMenuBarItem()
+        let menu = TrackingMenu(title: "Issue 533 Color")
+        let colorItem = try #require(item.buildMenuItem(params: MenuLineParameters(
+            line: "PDF telecharge aujourd'hui : 0 PDF | color=green"
+        )))
+        menu.addItem(colorItem)
+        menu.changedItems.removeAll()
+
+        let originalTitle = try #require(colorItem.attributedTitle)
+        #expect(colorItem.isEnabled)
+
+        item.menu(menu, willHighlight: colorItem)
+        #expect(menu.changedItems.count == 1)
+        #expect(menu.changedItems.first === colorItem)
+        #expect(colorItem.attributedTitle === originalTitle)
+        #expect(colorItem.attributedTitle?.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor == .selectedMenuItemTextColor)
+
+        item.menu(menu, willHighlight: colorItem)
+        #expect(menu.changedItems.count == 1)
+
+        item.menu(menu, willHighlight: nil)
+        #expect(menu.changedItems.count == 2)
+        #expect(menu.changedItems.last === colorItem)
+        #expect(colorItem.attributedTitle === originalTitle)
+        #expect(colorItem.attributedTitle?.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor == NSColor.webColor(from: "green"))
+
+        item.menu(menu, willHighlight: nil)
+        #expect(menu.changedItems.count == 2)
+    }
+
+    @MainActor @Test func testPlainHighlightTracksIncrementallyReplacedTitle() throws {
+        guard !MenubarItem.shouldRewriteAttributedTitlesDuringMenuTracking() else { return }
+
+        let item = makeMenuBarItem()
+        item._updateMenu(content: """
+        Title
+        ---
+        Count: 1 | color=green
+        """)
+        let colorItem = try #require(menuItem(named: "Count: 1", in: item.statusBarMenu))
+
+        item.menu(item.statusBarMenu, willHighlight: colorItem)
+        let originalTitle = try #require(colorItem.attributedTitle)
+        #expect(originalTitle.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor == .selectedMenuItemTextColor)
+
+        item._updateMenu(content: """
+        Title
+        ---
+        Count: 2 | color=green
+        """)
+        #expect(menuItem(named: "Count: 2", in: item.statusBarMenu) === colorItem)
+        #expect(colorItem.attributedTitle !== originalTitle)
+
+        item.menu(item.statusBarMenu, willHighlight: colorItem)
+        #expect(colorItem.attributedTitle?.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor == .selectedMenuItemTextColor)
     }
 
     @Test func testHighlightTitleRewriteStopsAtMacOS26Boundary() {

--- a/SwiftBarTests/SwiftBarTests.swift
+++ b/SwiftBarTests/SwiftBarTests.swift
@@ -3345,6 +3345,21 @@ struct FoldMenuItemBuildTests {
     }
 
     @MainActor
+    private func textBounds(_ text: String, in title: NSAttributedString) -> NSRect {
+        let textStorage = NSTextStorage(attributedString: title)
+        let layoutManager = NSLayoutManager()
+        let textContainer = NSTextContainer(size: NSSize(width: 2_000, height: 2_000))
+        textContainer.lineFragmentPadding = 0
+        layoutManager.addTextContainer(textContainer)
+        textStorage.addLayoutManager(layoutManager)
+        layoutManager.ensureLayout(for: textContainer)
+
+        let characterRange = (title.string as NSString).range(of: text)
+        let glyphRange = layoutManager.glyphRange(forCharacterRange: characterRange, actualCharacterRange: nil)
+        return layoutManager.boundingRect(forGlyphRange: glyphRange, in: textContainer)
+    }
+
+    @MainActor
     private func renderedAttachment(
         from item: NSMenuItem,
         appearance: NSAppearance.Name,
@@ -3429,6 +3444,50 @@ struct FoldMenuItemBuildTests {
             #expect(menuImage.size == NSSize(width: 30, height: 12))
             #expect(!menuImage.isTemplate)
         }
+    }
+
+    @MainActor @Test func testAttributedPresentation_alignsMultilineTitleAfterImage() throws {
+        let item = makeMenuBarItem()
+        let image = try makeBase64PNG(size: NSSize(width: 30, height: 30))
+        let params = MenuLineParameters(line: "First line\\nSecond line\\nThird line | image=\(image)")
+        let menuItem = NSMenuItem()
+
+        item.configureMenuImage(
+            on: menuItem,
+            title: item.atributedTitle(with: params).title,
+            params: params,
+            presentation: .attributed
+        )
+
+        let title = try #require(menuItem.attributedTitle)
+        let firstLine = textBounds("First line", in: title)
+        let secondLine = textBounds("Second line", in: title)
+        let thirdLine = textBounds("Third line", in: title)
+
+        #expect(firstLine.minX > 0)
+        #expect(abs(firstLine.minX - secondLine.minX) < 0.01)
+        #expect(abs(firstLine.minX - thirdLine.minX) < 0.01)
+        #expect(try attachedImage(from: menuItem).size == NSSize(width: 30, height: 30))
+    }
+
+    @MainActor @Test func testAttributedPresentation_doesNotIndentMultilineTitleWithoutImage() throws {
+        let item = makeMenuBarItem()
+        let params = MenuLineParameters(line: "First line\\nSecond line")
+        let menuItem = NSMenuItem()
+
+        item.configureMenuImage(
+            on: menuItem,
+            title: item.atributedTitle(with: params).title,
+            params: params,
+            presentation: .attributed
+        )
+
+        let title = try #require(menuItem.attributedTitle)
+        let firstLine = textBounds("First line", in: title)
+        let secondLine = textBounds("Second line", in: title)
+
+        #expect(abs(firstLine.minX - secondLine.minX) < 0.01)
+        #expect(firstLine.minX < 0.01)
     }
 
     @MainActor @Test func testIncrementalRefresh_preservesReporterImagePointSizeAndReplacesInPlace() throws {


### PR DESCRIPTION
## Summary

- align wrapped and explicit continuation lines with text following an inline menu image
- notify AppKit when tracked custom colors change on hover, without replacing the attributed title
- preserve highlight state when an incremental refresh replaces the same row's title
- leave `sfsize` and default SF Symbol sizing unchanged

## Root cause

The macOS 26+ inline-image path prepended an attachment but retained a zero paragraph indent, so continuation lines started beneath the image. The custom-color wrapper changed its reported color on hover, but the menu was not told that its item needed redrawing, leaving stale pixels after the pointer moved away.

Actionless colored rows remain enabled and highlightable by design. This change restores their selected contrast and custom color after hover.

## Validation

- focused `FoldMenuItemBuildTests`: 25 passed
- full macOS test suite: 215 passed
- baseline `origin/main` with the new tests: both reported regressions fail
- fault mutations: alignment, redraw invalidation, and incremental-title guards each fail independently
- Universal Release build: arm64 + x86_64, version 2.1.2 build 604
- final Codex review: no actionable findings
- umputun maintainer gate: passed

Validation ran on macOS 27.0 beta with Xcode 27.0 beta. The preserved reporter artifacts provide the macOS 26.5.2 visual evidence; state-level tests exercise the affected AppKit paths directly.

Closes #533