### PR TITLE
fix(plugin): make `**` in .swiftbarignore span any directory depth

### DIFF
--- a/SwiftBar/Plugin/PluginManger.swift
+++ b/SwiftBar/Plugin/PluginManger.swift
@@ -171,6 +171,39 @@ func knownMenuBarManagerMatches(in applicationNames: [String]) -> [String] {
     }
 }
 
+/// Translates a `.swiftbarignore` glob into a regex.
+///
+/// `escapedPattern(for:)` escapes `/` as `\/`, so the `**/` token has to be matched in its
+/// escaped spelling. Matching the unescaped spelling silently turns `**` into two adjacent
+/// `[^/]*`, which pins the pattern to one fixed directory depth instead of any depth.
+func swiftBarIgnoreRegexPattern(for pattern: String) -> String {
+    let escaped = NSRegularExpression.escapedPattern(for: pattern)
+        .replacingOccurrences(of: "\\*\\*\\/", with: "(.*/)?") // ** matches any directory depth
+        .replacingOccurrences(of: "\\*\\*/", with: "(.*/)?") // ...also when `/` is left unescaped
+        .replacingOccurrences(of: "\\*", with: "[^/]*") // * matches within directory
+        .replacingOccurrences(of: "\\?", with: "[^/]") // ? matches single character
+    return "^\(escaped)$"
+}
+
+/// Whether a single `.swiftbarignore` pattern matches an entry, by filename or by the path
+/// relative to the plugin directory.
+func swiftBarIgnorePatternMatches(pattern: String, filename: String, relativePath: String) -> Bool {
+    // Direct filename match
+    if filename == pattern || relativePath == pattern {
+        return true
+    }
+
+    guard let regex = try? NSRegularExpression(pattern: swiftBarIgnoreRegexPattern(for: pattern), options: []) else {
+        return false
+    }
+
+    // Try to match against both filename and relative path
+    let filenameRange = NSRange(location: 0, length: filename.utf16.count)
+    let pathRange = NSRange(location: 0, length: relativePath.utf16.count)
+    return regex.firstMatch(in: filename, options: [], range: filenameRange) != nil
+        || regex.firstMatch(in: relativePath, options: [], range: pathRange) != nil
+}
+
 func statusItemPersistenceEntries(in defaults: [String: Any]) -> [String] {
     defaults.keys
         .filter { $0.hasPrefix("NSStatusItem ") }
@@ -496,31 +529,9 @@ class PluginManager: ObservableObject {
                 let relativePath = url.path.replacingOccurrences(of: baseURL.path + "/", with: "")
                 let filename = url.lastPathComponent
 
-                for pattern in patterns {
-                    // Direct filename match
-                    if filename == pattern || relativePath == pattern {
-                        return true
-                    }
-
-                    // Convert glob pattern to regex
-                    let escapedPattern = NSRegularExpression.escapedPattern(for: pattern)
-                        .replacingOccurrences(of: "\\*\\*/", with: "(.*/)?") // ** matches any directory depth
-                        .replacingOccurrences(of: "\\*", with: "[^/]*") // * matches within directory
-                        .replacingOccurrences(of: "\\?", with: "[^/]") // ? matches single character
-
-                    // Try to match against both filename and relative path
-                    if let regex = try? NSRegularExpression(pattern: "^\(escapedPattern)$", options: []) {
-                        let filenameRange = NSRange(location: 0, length: filename.utf16.count)
-                        let pathRange = NSRange(location: 0, length: relativePath.utf16.count)
-
-                        if regex.firstMatch(in: filename, options: [], range: filenameRange) != nil ||
-                            regex.firstMatch(in: relativePath, options: [], range: pathRange) != nil
-                        {
-                            return true
-                        }
-                    }
+                return patterns.contains { pattern in
+                    swiftBarIgnorePatternMatches(pattern: pattern, filename: filename, relativePath: relativePath)
                 }
-                return false
             }
 
             let filteredFiles = files.filter { !shouldBeIgnored(url: $0, patterns: ignorePatterns, baseURL: url) }

--- a/SwiftBarTests/SwiftBarTests.swift
+++ b/SwiftBarTests/SwiftBarTests.swift
@@ -355,6 +355,58 @@ struct SwiftBarTests {
         #expect(shouldLoadPluginFile(at: symlinkURL, makePluginExecutable: false))
     }
 
+    // MARK: - .swiftbarignore glob matching
+
+    @Test func testSwiftBarIgnoreRegexPattern_expandsDoubleStarToAnyDepth() {
+        // `escapedPattern(for:)` escapes `/` as `\/`. If the `**/` token is only replaced in
+        // its unescaped spelling the substitution silently no-ops and `**` decays into two
+        // adjacent `[^/]*`, pinning the pattern to one fixed depth.
+        #expect(swiftBarIgnoreRegexPattern(for: "__pycache__/**/*") == "^__pycache__\\/(.*/)?[^/]*$")
+        #expect(swiftBarIgnoreRegexPattern(for: "**/node_modules") == "^(.*/)?node_modules$")
+        #expect(!swiftBarIgnoreRegexPattern(for: "__pycache__/**/*").contains("[^/]*[^/]*"))
+    }
+
+    @Test func testSwiftBarIgnorePatternMatches_globSemantics() {
+        // (pattern, path relative to the plugin directory, should be ignored)
+        let cases: [(pattern: String, relativePath: String, expected: Bool)] = [
+            // `**/` spans any number of directories, including none at all
+            ("__pycache__/**/*", "__pycache__/mod.cpython-314.pyc", true),
+            ("__pycache__/**/*", "__pycache__/sub/mod.cpython-314.pyc", true),
+            ("__pycache__/**/*", "__pycache__/a/b/mod.cpython-314.pyc", true),
+            ("__pycache__/**/*", "src/mod.cpython-314.pyc", false),
+            ("**/node_modules", "node_modules", true),
+            ("**/node_modules", "vendor/node_modules", true),
+            ("**/node_modules", "a/b/node_modules", true),
+            ("**/node_modules", "node_modules_backup", false),
+            // a bare `*` stays inside a single path component
+            ("build/*", "build/out.sh", true),
+            ("build/*", "build/sub/out.sh", false),
+            // a filename-only glob matches at any depth, via the filename arm
+            ("*.pyc", "mod.pyc", true),
+            ("*.pyc", "sub/deeper/mod.pyc", true),
+            ("*.pyc", "mod.py", false),
+            // `?` is exactly one non-separator character
+            ("plugin.?m.sh", "plugin.5m.sh", true),
+            ("plugin.?m.sh", "plugin.15m.sh", false),
+            ("plugin.?m.sh", "plugin./m.sh", false),
+            // regex metacharacters inside patterns stay literal
+            ("weather (*).sh", "weather (1).sh", true),
+            ("a+b.sh", "aab.sh", false),
+            ("report.txt", "report.txt", true),
+            ("docs/report.txt", "docs/report.txt", true),
+        ]
+
+        for testCase in cases {
+            let filename = (testCase.relativePath as NSString).lastPathComponent
+            let matched = swiftBarIgnorePatternMatches(
+                pattern: testCase.pattern,
+                filename: filename,
+                relativePath: testCase.relativePath
+            )
+            #expect(matched == testCase.expected, "\(testCase.pattern) vs \(testCase.relativePath)")
+        }
+    }
+
     @Test func testRunPluginOperation_rearmsTimersForTimerArmingPlugins() {
         let plugin = TimedTestPlugin(id: "timed-plugin", file: "/tmp/timed.5s.sh", invokeResult: "updated")
         let operation = RunPluginOperation(plugin: plugin)


### PR DESCRIPTION
## Problem

The `**/` → `(.*/)?` expansion in `.swiftbarignore` matching never fires, so `**` has never worked.

`NSRegularExpression.escapedPattern(for:)` escapes `/` (it escapes ``$ ( ) * + . / ? [ \ ^ { | }``), so the escaped pattern contains `\*\*\/` — while the substitution searches for the literal `\*\*/`:

```swift
let escapedPattern = NSRegularExpression.escapedPattern(for: pattern)
    .replacingOccurrences(of: "\\*\\*/", with: "(.*/)?") // searches for \*\*/ ; string holds \*\*\/
```

With the replacement a no-op, `**` decays into two adjacent `[^/]*` and every separator stays literal, pinning a pattern to one fixed depth:

| pattern | resulting regex | actually matches |
|---|---|---|
| `__pycache__/**/*` | `^__pycache__\/[^/]*[^/]*\/[^/]*$` | only `__pycache__/a/b`, never `__pycache__/a` |
| `**/node_modules` | `^[^/]*[^/]*\/node_modules$` | only `x/node_modules` |
| `docs/**` | `^docs\/[^/]*[^/]*$` | depth 1 only |

Because `getPluginList()` flattens every depth into one file list before matching per file (a bare `__pycache__` entry only skips the redundant second-pass scan), there is currently no working way to ignore a directory's contents at arbitrary depth. Only filename globs like `*.pyc` do anything, via the `lastPathComponent` arm.

### Repro without building SwiftBar

```swift
import Foundation
var p = NSRegularExpression.escapedPattern(for: "__pycache__/**/*")
print(p)                                                    // __pycache__\/\*\*\/\*
p = p.replacingOccurrences(of: "\\*\\*/", with: "(.*/)?")   // no-op
p = p.replacingOccurrences(of: "\\*", with: "[^/]*")
print("^\(p)$")                                             // ^__pycache__\/[^/]*[^/]*\/[^/]*$
```

How I ran into it: `.pyc` files under `plugin_dir/__pycache__/` kept being made executable and run as plugins — failing, so the menu bar showed the `􀇾` error item — even though `.swiftbarignore` listed `__pycache__/**/*`. Observed on 2.1.1 (597) and current `main`.

## Fix

Match the escaped spelling too (the unescaped one is kept so the code does not depend on which characters `escapedPattern` escapes on a given OS release).

The matcher is extracted into two file-scope functions so it can be unit tested, following the existing convention of `shouldLoadPluginFile` / `pluginFileSkipReason` / `systemReportCandidateStatus`. `shouldBeIgnored` keeps its signature and behaviour otherwise.

## Tests

Two new tests in `SwiftBarTests` — a table over 20 (pattern, path, expected) cases covering `**/` at zero/one/many depths, `*` not crossing separators, `?` as a single non-separator character, filename globs matching at any depth, and regex metacharacters staying literal.

- Full suite on `main` + these tests: **TEST FAILED** (both new tests, 7 assertions)
- Full suite with the fix: **TEST SUCCEEDED**

Verified with Xcode 26.6 on macOS 26.5, `xcodebuild test -scheme SwiftBar -destination 'platform=macOS'`. `swiftformat --lint` reports no differences in the changed lines.

## Not addressed here — happy to follow up if you'd like them

1. A trailing `dir/**` (no `/*`) still means "exactly one more component", since only the `**/` token is translated. `gitignore` users would expect "everything under dir".
2. A bare directory entry does not protect its contents, because the first enumerator pass already flattened all depths into `files`. Calling `enumerator.skipDescendants()` for ignored directories would make the bare-dir form behave as people expect and shrink the scan.
3. `.swiftbarignore` had no test coverage before this PR, which is also how #436 got through.